### PR TITLE
[EXOD-000] Fix issue with precision calc for bonds

### DIFF
--- a/src/helpers/index.tsx
+++ b/src/helpers/index.tsx
@@ -54,7 +54,8 @@ export function formatCurrency(c: number, precision = 0) {
 export function trim(number = 0, precision = 0) {
   // why would number ever be undefined??? what are we trimming?
   const array = number.toString().split(".");
-  if (number < 10 ** -precision) return 0;
+  if (number > 0 && number < 10 ** -precision) return 0;
+  if (number < 0 && number > -(10 ** -precision)) return 0;
   if (array.length === 1) return number.toString();
   if (precision === 0) return array[0].toString();
 


### PR DESCRIPTION
Negative bonds were displaying 0 due to a recent change regarding precision.

The precision calculation didn't take negative values into account and always returned 0

The check has been modified to only check against positive numbers
While an inverse check has been added to apply the same to negative numbers
![Screenshot from 2021-11-26 21-03-48](https://user-images.githubusercontent.com/86249394/143586772-985b7e56-a516-49e1-b882-8a42078e7034.png)
![Screenshot from 2021-11-26 21-04-36](https://user-images.githubusercontent.com/86249394/143586782-5a5be753-2c9e-4d9e-92a4-67b3c08ae442.png)


