### PR TITLE
[EXOD-004] Fix issue with site  refreshing on first visit

### DIFF
--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -28,7 +28,7 @@ const ALL_URIs = NodeHelper.getNodesUris();
  * @returns string
  */
 function getMainnetURI(): string {
-  return "https://rpc.ftm.tools/";
+  return "https://rpc.ftm.tools";
 }
 
 /*


### PR DESCRIPTION
## The problem
- Site was doing a hard refresh on first visit.
- This only occurred when it was the first visit on the same tab. Refreshing a new tab wouldn't reproduce it.
## Changes
- Change the `getMainnetURI` function to return `https://rpc.ftm.tools` instead of `https://rps.ftm.tools/`

Debugger shows the exact point of issue:
![Screenshot from 2021-11-30 01-06-28](https://user-images.githubusercontent.com/86249394/143914128-5039f336-73f0-4db6-aa90-7fd9e8fe2534.png)
