### PR TITLE
[EXOD-008] Prevent users from bonding less than the min

### DIFF
--- a/src/views/Bond/BondPurchase.jsx
+++ b/src/views/Bond/BondPurchase.jsx
@@ -190,7 +190,7 @@ function BondPurchase({ bond, slippage, recipientAddress }) {
                     color="primary"
                     id="bond-btn"
                     className="transaction-button"
-                    disabled={isPendingTxn(pendingTransactions, "bond_" + bond.name)}
+                    disabled={isPendingTxn(pendingTransactions, "bond_" + bond.name) || bond.purchaseDisabled}
                     onClick={onBond}
                   >
                     <TxnButtonText


### PR DESCRIPTION
## The Problem
Users are getting a JSON-RPC error when attempting to bond less than the minimum.

- There is a minimum bond amount of 0.01 EXOD per bond, when users entered their deposit, regardless of deposit amount, if the payout was less than 0.01 EXOD, this would result in a JSON-RPC error (TX will fail if executed)

## Changes
The numbers used to check the minimum were off by 2 digits, I suppose this is left over from OHM which needed changing. Bumping these up by 2 solves the issue and works exactly for payouts worth 0.0099 EXOD (prevents and warns) and 0.01 EXOD (allows)

- Error toast will flash when entering below 0.01 EXOD
- Purchase Bond button will be disabled when entering below 0.01 EXOD
- Purchase Bond button will be disabled when purchasing above the max amount of allowed EXOD per bond

**Line in contract**
(This is in every EXOD bond contract, equates to 0.01 EXOD still)
![Screenshot from 2021-11-30 01-46-53](https://user-images.githubusercontent.com/86249394/143919986-db22455c-7350-4568-91fc-70b461e4e1a0.png)

**Visual**
![bond-json-rpc_1](https://user-images.githubusercontent.com/86249394/143920182-46c7b22a-44b0-4ed6-8c22-b7a5ea04a440.gif)

