### PR TITLE
[EXOD-011] Add tooltip to obliterator link

### DIFF
--- a/src/components/Sidebar/NavContent.jsx
+++ b/src/components/Sidebar/NavContent.jsx
@@ -16,6 +16,7 @@ import { Paper, Link, Box, Typography, SvgIcon } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 import StarIcon from "@material-ui/icons/Stars";
 import HomeIcon from "@material-ui/icons/Home";
+import Tooltip from "@material-ui/core/Tooltip";
 import "./sidebar.scss";
 
 function NavContent() {
@@ -143,10 +144,14 @@ function NavContent() {
                 }}
                 className={`button-dapp-menu ${isActive ? "active" : ""} obliterator`}
               >
-                <Typography variant="h6" className="obliterator">
-                  <SvgIcon color="primary" component={StarIcon} />
-                  <Trans>Obliterator</Trans>
-                </Typography>
+                <Tooltip
+                  title={<Trans>Estimate and visualize your potential returns over time by staking with Exodia</Trans>}
+                >
+                  <Typography variant="h6" className="obliterator">
+                    <SvgIcon color="primary" component={StarIcon} />
+                    <Trans>Obliterator</Trans>
+                  </Typography>
+                </Tooltip>
               </Link>
             </div>
           </div>

--- a/src/themes/dark.js
+++ b/src/themes/dark.js
@@ -108,6 +108,11 @@ export const dark = responsiveFontSizes(
             },
           },
         },
+        MuiTooltip: {
+          tooltip: {
+            fontSize: "1.1em",
+          },
+        },
         MuiBackdrop: {
           root: {
             backgroundColor: darkTheme.backdropBg,


### PR DESCRIPTION
**Changes**
- Adds tooltip to the obliterator nav link. As discussed [here](https://discord.com/channels/913600368703860826/913608972504793138/916317029932359781)
![Screenshot-from-2021-12-04-02-36-52](https://user-images.githubusercontent.com/86249394/144664112-8192efcc-8710-4bca-b537-5cc900abcec3.png)


