### PR TITLE
[EXOD-010] Calculator internationalization and Calc Chart

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/locales/translations"]
 	path = src/locales/translations
-	url = https://github.com/OlympusDAO/olympus-translations
+	url = https://github.com/ExodiaFinance/exodia-translations.git
 	branch = develop

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [Exodia Frontend](https://app.exodia.fi/)
-This is the front-end repo for Olympus that allows users be part of the future of Greece. 
+This is the front-end repo for Exodia that allows users be part of the future of Greece. 
 
 **_ Note We're currently in the process of switching to TypeScript. Please read  this  guide on how to use TypeScript for this repository. https://github.com/OlympusDAO/olympus-frontend/wiki/TypeScript-Refactor-General-Guidelines _**
 
@@ -12,7 +12,7 @@ Required:
 
 
 ```bash
-$ git clone https://github.com/OlympusDAO/olympusdao.git
+$ git clone --recurse-submodules https://github.com/ExodiaFinance/exodia-frontend
 $ cd olympusdao
 
 # set up your environment variables
@@ -59,6 +59,13 @@ The files/folder structure are a  **WIP** and may contain some unused files. The
 Olympus uses [linguijs](https://github.com/lingui/js-lingui) to manage translation.
 
 The language files are located in a submodule deployed in `src/locales/translations`. This submodule points to the [olympus translation repository](https://github.com/OlympusDAO/olympus-translations)
+
+For the translations to run locally, you must pull the submodlue and compile the translations:
+```
+git submodule update --init --recursive
+yarn lingui:extract
+yarn lingui:compile
+```
 
 In order to mark text for translation you can use:
 - The <Trans> component in jsx templates eg. `<Trans>Translate me!</Trans>`

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -230,6 +230,7 @@ const renderLineChart = (
   expandedGraphStrokeColor,
   scale,
   xInterval = 100,
+  domain,
 ) => (
   <LineChart data={data}>
     <XAxis
@@ -252,7 +253,7 @@ const renderLineChart = (
       tickFormatter={number =>
         number !== 0 ? (dataFormat !== "percent" ? `${number}` : `${parseFloat(number) / 1000}k`) : ""
       }
-      domain={[scale == "log" ? "dataMin" : 0, "auto"]}
+      domain={domain || [scale == "log" ? "dataMin" : 0, "auto"]}
       connectNulls={true}
       allowDataOverflow={false}
     />
@@ -435,6 +436,7 @@ function Chart({
   isDebt,
   todayMessage = "Today",
   xInterval,
+  domain,
 }) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -475,6 +477,7 @@ function Chart({
         expandedGraphStrokeColor,
         scale,
         xInterval,
+        domain,
       );
     if (type === "area")
       return renderAreaChart(
@@ -580,6 +583,7 @@ function Chart({
             infoTooltipMessage={infoTooltipMessage}
             headerText={headerText}
             headerSubText={headerSubText}
+            todayMessage={todayMessage}
           />
         </Box>
         {loading ? (

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -81,8 +81,8 @@ const renderAreaChart = (
           ? dataFormat === "percent"
             ? `${trim(parseFloat(number), 2)}%`
             : dataFormat === "OHM"
-              ? number
-              : `${formatCurrency(parseFloat(number) / 1000000)}M`
+            ? number
+            : `${formatCurrency(parseFloat(number) / 1000000)}M`
           : ""
       }
       domain={[0, "auto"]}
@@ -229,11 +229,12 @@ const renderLineChart = (
   isExpanded,
   expandedGraphStrokeColor,
   scale,
+  xInterval = 100,
 ) => (
   <LineChart data={data}>
     <XAxis
       dataKey="timestamp"
-      interval={100}
+      interval={xInterval}
       axisLine={false}
       tickCount={3}
       tickLine={false}
@@ -293,7 +294,9 @@ const renderMultiLineChart = (
       axisLine={false}
       tickLine={false}
       width={25}
-      tickFormatter={number => (number !== 0 ? dataFormat !== "percent" ? `${trim(parseFloat(number), 2)}` : `${number}%` : "")}
+      tickFormatter={number =>
+        number !== 0 ? (dataFormat !== "percent" ? `${trim(parseFloat(number), 2)}` : `${number}%`) : ""
+      }
       domain={[0, "auto"]}
       connectNulls={true}
       allowDataOverflow={false}
@@ -401,17 +404,12 @@ const renderComposedChart = (
     />
     <Tooltip
       // formatter={value => trim(parseFloat(value), 2)}
-      content={<CustomTooltip itemNames={itemNames} itemType={itemType} bulletpointColors={bulletpointColors} isDilution />}
+      content={
+        <CustomTooltip itemNames={itemNames} itemType={itemType} bulletpointColors={bulletpointColors} isDilution />
+      }
     />
     <Area yAxisId="left" dataKey={dataKey[0]} stroke="none" fill={`url(#color-${dataKey[0]})`} fillOpacity={1} />
-    <Line
-      yAxisId="right"
-      type="basis"
-      dataKey={dataKey[1]}
-      stroke={stroke}
-      strokeWidth={3}
-      dot={false}
-    />;
+    <Line yAxisId="right" type="basis" dataKey={dataKey[1]} stroke={stroke} strokeWidth={3} dot={false} />;
     {renderExpandedChartStroke(isExpanded, expandedGraphStrokeColor)}
   </ComposedChart>
 );
@@ -435,6 +433,8 @@ function Chart({
   expandedGraphStrokeColor,
   isPOL,
   isDebt,
+  todayMessage = "Today",
+  xInterval,
 }) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -474,6 +474,7 @@ function Chart({
         isExpanded,
         expandedGraphStrokeColor,
         scale,
+        xInterval,
       );
     if (type === "area")
       return renderAreaChart(
@@ -589,7 +590,7 @@ function Chart({
               {headerSubText}
             </Typography>
             <Typography variant="h4" color="textSecondary" style={{ fontWeight: 400 }}>
-              {itemNames === tooltipItems.mcs || itemNames === tooltipItems.minted ? "5-day Average" : "Today"}
+              {type !== "multi" && todayMessage}
             </Typography>
           </Box>
         )}

--- a/src/components/Chart/ExpandedChart.jsx
+++ b/src/components/Chart/ExpandedChart.jsx
@@ -13,6 +13,7 @@ function ExpandedChart({
   headerText,
   headerSubText,
   runwayExtraInfo,
+  todayMessage,
 }) {
   const verySmallScreen = useMediaQuery("(max-width: 379px)");
 
@@ -49,9 +50,11 @@ function ExpandedChart({
                   {headerSubText}
                 </Typography>
                 {runwayExtraInfo}
-                <Typography variant="h4" color="textSecondary" style={{ fontWeight: 400 }}>
-                  Today
-                </Typography>
+                {todayMessage && (
+                  <Typography variant="h4" color="textSecondary" style={{ fontWeight: 400 }}>
+                    {todayMessage}
+                  </Typography>
+                )}
               </Box>
             </div>
 

--- a/src/components/Chart/PersonalExodChart.tsx
+++ b/src/components/Chart/PersonalExodChart.tsx
@@ -39,10 +39,11 @@ const PersonalExodChart = ({
 }: PersonalExodChartProps) => {
   const theme = useTheme();
   const [mode, setMode] = useState(stakingView ? "USD" : "sEXOD");
+  const defaultExod = stakingView ? 1 : 0;
   const data =
     mode === "sEXOD"
-      ? calcSExodChart(calcDays, exodAmount || 1, rebaseRate)
-      : calcUsdChart(calcDays, exodAmount || 1, rebaseRate, finalExodPrice, exodPrice);
+      ? calcSExodChart(calcDays, exodAmount || defaultExod, rebaseRate)
+      : calcUsdChart(calcDays, exodAmount || defaultExod, rebaseRate, finalExodPrice, exodPrice);
 
   const switchMode = () => {
     setMode(mode === "sEXOD" ? "USD" : "sEXOD");
@@ -64,26 +65,15 @@ const PersonalExodChart = ({
       domain={["dataMin", "auto"]}
       data={data}
       dataKey={[mode]}
-      headerText={[
-        <HeaderContainer>
-          <SwitchToUSD onClick={switchMode}>
-            <Trans>Switch to</Trans> {mode === "sEXOD" ? "USD" : "sEXOD"}
-          </SwitchToUSD>
-        </HeaderContainer>,
-      ]}
+      headerText={[<HeaderText mode={mode} switchMode={switchMode} />]}
       headerSubText={
-        <>
-          <Trans>
-            {profits} after {calcDays} days
-          </Trans>
-          {stakingView && mode === "USD" && (
-            <>
-              {" "}
-              <Trans>if price remains stable</Trans>
-            </>
-          )}
-          {exodAmount === 0 && <> ({t`Staking`} 1 EXOD)</>}
-        </>
+        <HeaderSubText
+          profits={profits}
+          calcDays={calcDays}
+          stakingView={stakingView}
+          mode={mode}
+          exodAmount={exodAmount}
+        />
       }
       itemNames={[mode]}
       todayMessage=""
@@ -93,13 +83,7 @@ const PersonalExodChart = ({
       infoTooltipMessage={mode === "sEXOD" ? infoTooltipMessage : usdTooltip}
       expandedGraphStrokeColor={theme.palette.graphStrokeColor}
       xInterval={30}
-      bulletpointColors={[
-        {
-          right: 20,
-          top: -12,
-          background: darkTheme.gold,
-        },
-      ]}
+      bulletpointColors={bulletpointColors}
     />
   );
 };
@@ -144,6 +128,53 @@ const calcUsdChart = (
 const nowPlusDays = (days: number) => {
   return Date.now() / 1000 + 86400 * days;
 };
+
+const HeaderText = ({ mode, switchMode }: { mode: string; switchMode: () => void }) => {
+  return (
+    <HeaderContainer>
+      <SwitchToUSD onClick={switchMode}>
+        <Trans>Switch to</Trans> {mode === "sEXOD" ? "USD" : "sEXOD"}
+      </SwitchToUSD>
+    </HeaderContainer>
+  );
+};
+
+const HeaderSubText = ({
+  profits,
+  calcDays,
+  stakingView,
+  mode,
+  exodAmount,
+}: {
+  profits: number;
+  calcDays: number;
+  stakingView: boolean;
+  mode: string;
+  exodAmount: number;
+}) => {
+  return (
+    <>
+      <Trans>
+        {profits} after {calcDays} days
+      </Trans>
+      {stakingView && mode === "USD" && (
+        <>
+          {" "}
+          <Trans>if price remains stable</Trans>
+        </>
+      )}
+      {!exodAmount && stakingView && <> ({t`Staking`} 1 EXOD)</>}
+    </>
+  );
+};
+
+const bulletpointColors = [
+  {
+    right: 20,
+    top: -12,
+    background: darkTheme.gold,
+  },
+];
 
 const HeaderContainer = styled.div`
   display: flex;

--- a/src/components/Chart/PersonalExodChart.tsx
+++ b/src/components/Chart/PersonalExodChart.tsx
@@ -38,7 +38,7 @@ const PersonalExodChart = ({
   stakingView,
 }: PersonalExodChartProps) => {
   const theme = useTheme();
-  const [mode, setMode] = useState("sEXOD");
+  const [mode, setMode] = useState(stakingView ? "USD" : "sEXOD");
   const data =
     mode === "sEXOD"
       ? calcSExodChart(calcDays, exodAmount, rebaseRate)

--- a/src/components/Chart/PersonalExodChart.tsx
+++ b/src/components/Chart/PersonalExodChart.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "@material-ui/core/styles";
 import Chart from "src/components/Chart/Chart";
 import { trim, formatCurrency } from "src/helpers";
 import { darkTheme } from "src/themes/dark.js";
-import { Trans } from "@lingui/macro";
+import { Trans, t } from "@lingui/macro";
 import { calcYieldPercent, calcTotalExod } from "../../views/Calc/formulas";
 import styled from "styled-components";
 
@@ -41,8 +41,8 @@ const PersonalExodChart = ({
   const [mode, setMode] = useState(stakingView ? "USD" : "sEXOD");
   const data =
     mode === "sEXOD"
-      ? calcSExodChart(calcDays, exodAmount, rebaseRate)
-      : calcUsdChart(calcDays, exodAmount, rebaseRate, finalExodPrice, exodPrice);
+      ? calcSExodChart(calcDays, exodAmount || 1, rebaseRate)
+      : calcUsdChart(calcDays, exodAmount || 1, rebaseRate, finalExodPrice, exodPrice);
 
   const switchMode = () => {
     setMode(mode === "sEXOD" ? "USD" : "sEXOD");
@@ -57,7 +57,7 @@ const PersonalExodChart = ({
           maximumFractionDigits: 2,
           minimumFractionDigits: 2,
         }).format(data[0][mode]);
-
+  console.log(exodAmount);
   return (
     <Chart
       type="line"
@@ -82,6 +82,7 @@ const PersonalExodChart = ({
               <Trans>if price remains stable</Trans>
             </>
           )}
+          {exodAmount === 0 && <> ({t`Staking`} 1 EXOD)</>}
         </>
       }
       itemNames={[mode]}

--- a/src/components/Chart/PersonalExodChart.tsx
+++ b/src/components/Chart/PersonalExodChart.tsx
@@ -4,15 +4,16 @@ import Chart from "src/components/Chart/Chart";
 import { trim, formatCurrency } from "src/helpers";
 import { darkTheme } from "src/themes/dark.js";
 import { Trans } from "@lingui/macro";
-import { calcYieldPercent, calcTotalExod } from "./formulas";
+import { calcYieldPercent, calcTotalExod } from "../../views/Calc/formulas";
 import styled from "styled-components";
 
-type CalcChartProps = {
+type PersonalExodChartProps = {
   calcDays: number;
   exodAmount: number;
   rebaseRate: number;
   finalExodPrice: number;
   exodPrice: number;
+  stakingView?: boolean;
 };
 
 const infoTooltipMessage = (
@@ -28,7 +29,14 @@ const usdTooltip = (
   </Trans>
 );
 
-const CalcChart = ({ calcDays, exodAmount, rebaseRate, finalExodPrice, exodPrice }: CalcChartProps) => {
+const PersonalExodChart = ({
+  calcDays,
+  exodAmount,
+  rebaseRate,
+  finalExodPrice,
+  exodPrice,
+  stakingView,
+}: PersonalExodChartProps) => {
   const theme = useTheme();
   const [mode, setMode] = useState("sEXOD");
   const data =
@@ -64,9 +72,17 @@ const CalcChart = ({ calcDays, exodAmount, rebaseRate, finalExodPrice, exodPrice
         </HeaderContainer>,
       ]}
       headerSubText={
-        <Trans>
-          {profits} after {calcDays} days
-        </Trans>
+        <>
+          <Trans>
+            {profits} after {calcDays} days
+          </Trans>
+          {stakingView && mode === "USD" && (
+            <>
+              {" "}
+              <Trans>if price remains stable</Trans>
+            </>
+          )}
+        </>
       }
       itemNames={[mode]}
       todayMessage=""
@@ -87,7 +103,7 @@ const CalcChart = ({ calcDays, exodAmount, rebaseRate, finalExodPrice, exodPrice
   );
 };
 
-export default CalcChart;
+export default PersonalExodChart;
 
 const calcSExodChart = (calcDays: number, exodAmount: number, rebaseRate: number) => {
   const data = [];

--- a/src/components/TxnButtonText.jsx
+++ b/src/components/TxnButtonText.jsx
@@ -1,17 +1,18 @@
 import styled from "styled-components";
+import { Trans } from "@lingui/macro";
 import { IPendingTx, isPendingTxn } from "../slices/PendingTxnsSlice";
 
 type TxnButtonTextProps = {
   pendingTransactions: IPendingTxn[],
   type: string,
-  defaultText: string,
+  defaultText: any,
   size?: string,
 };
 
 const TxnButtonText = ({ pendingTransactions, type, defaultText, size = "small" }: TxnButtonTextProps) => {
   return isPendingTxn(pendingTransactions, type) ? (
     <TextContainer>
-      Pending...
+      <Trans>Pending...</Trans>
       <LoadingSpinner size="small" />
     </TextContainer>
   ) : (
@@ -29,7 +30,7 @@ export const TxnButtonTextGeneralPending = ({
 }: TxnButtonTextProps) => {
   return pendingTransactions.length >= 1 ? (
     <TextContainer>
-      Pending...
+      <Trans>Pending...</Trans>
       <LoadingSpinner size={size} />
     </TextContainer>
   ) : (

--- a/src/themes/dark.js
+++ b/src/themes/dark.js
@@ -7,7 +7,7 @@ import navBg from "../assets/images/exod-sidebar.jpg";
 // then set the values in darkTheme using the global color variables
 //green rgb(70,171,21)
 //dark green rgb(91,196,34)
-const darkTheme = {
+export const darkTheme = {
   color: "#FCFCFC",
   gold: "#46ab15", // Light green
   goldDimmed: "#376e1d",

--- a/src/views/33Together/PoolDeposit.jsx
+++ b/src/views/33Together/PoolDeposit.jsx
@@ -163,7 +163,7 @@ export const PoolDeposit = props => {
                 <TxnButtonText
                   pendingTransactions={pendingTransactions}
                   type="pool_deposit"
-                  defaultText={"Deposit sOHM"}
+                  defaultText={<Trans>Deposit sOHM</Trans>}
                 />
               </Button>
             ) : (
@@ -177,7 +177,7 @@ export const PoolDeposit = props => {
                 <TxnButtonText
                   pendingTransactions={pendingTransactions}
                   type="approve_pool_together"
-                  defaultText="Approve"
+                  defaultText={<Trans>Approve</Trans>}
                 />
               </Button>
             )}

--- a/src/views/33Together/PoolWithdraw.jsx
+++ b/src/views/33Together/PoolWithdraw.jsx
@@ -154,13 +154,13 @@ export const PoolWithdraw = props => {
                 <TxnButtonText
                   pendingTransactions={pendingTransactions}
                   type="pool_withdraw"
-                  defaultText={"Withdraw Early & pa" + exitFee + " sOHM"}
+                  defaultText={<Trans>Withdraw Early & pay {exitFee} sEXOD</Trans>}
                 />
               ) : (
                 <TxnButtonText
                   pendingTransactions={pendingTransactions}
                   type="pool_withdraw"
-                  defaultText={"Withdraw sOHM"}
+                  defaultText={<Trans>Withdraw sEXOD</Trans>}
                 />
               )}
               {/* Withdraw sOHM */}

--- a/src/views/Bond/BondPurchase.jsx
+++ b/src/views/Bond/BondPurchase.jsx
@@ -196,7 +196,7 @@ function BondPurchase({ bond, slippage, recipientAddress }) {
                     <TxnButtonText
                       pendingTransactions={pendingTransactions}
                       type={"bond_" + bond.name}
-                      defaultText="Bond"
+                      defaultText={<Trans>Bond</Trans>}
                     />
                   </Button>
                 ) : (
@@ -211,7 +211,7 @@ function BondPurchase({ bond, slippage, recipientAddress }) {
                     <TxnButtonText
                       pendingTransactions={pendingTransactions}
                       type={"approve_" + bond.name}
-                      defaultText="Approve"
+                      defaultText={<Trans>Approve</Trans>}
                     />
                   </Button>
                 )}

--- a/src/views/Bond/BondRedeem.jsx
+++ b/src/views/Bond/BondRedeem.jsx
@@ -73,7 +73,7 @@ function BondRedeem({ bond }) {
               <TxnButtonText
                 pendingTransactions={pendingTransactions}
                 type={"redeem_bond_" + bond.name}
-                defaultText="Claim"
+                defaultText={<Trans>Claim</Trans>}
               />
             </Button>
             <Button
@@ -93,7 +93,7 @@ function BondRedeem({ bond }) {
               <TxnButtonText
                 pendingTransactions={pendingTransactions}
                 type={"redeem_bond_" + bond.name + "_autostake"}
-                defaultText="Claim and Autostake"
+                defaultText={<Trans>Claim and Autostake</Trans>}
               />
             </Button>
           </>

--- a/src/views/Calc/Calc.tsx
+++ b/src/views/Calc/Calc.tsx
@@ -111,31 +111,31 @@ function Calc() {
               <ImportantValues {...{ marketPrice, stakingRebase, isAppLoading, trimmedBalance }} />
               <CalcArea>
                 <FieldInput
-                  fieldName="sEXOD Amount"
+                  field={<Trans>sEXOD Amount</Trans>}
                   value={exodAmountInput}
-                  maxName="Max"
+                  max={<Trans>Max</Trans>}
                   onChange={setExodAmountInput}
                   onMax={() => setExodAmountInput(trimmedBalance)}
                 />
                 <FieldInput
-                  fieldName="Rebase rate"
+                  field={<Trans>Rebase rate</Trans>}
                   value={Number(rebaseRateInput.toFixed(4))}
-                  maxName="Current"
+                  max={<Trans>Current</Trans>}
                   onChange={setRebaseRateInput}
                   onMax={() => setRebaseRateInput(stakingRebase * 100)}
                 />
                 <FieldInput
-                  fieldName="EXOD price at purchase ($)"
+                  field={<Trans>EXOD price at purchase ($)</Trans>}
                   value={Number(exodPriceInput.toFixed(2))}
-                  maxName="Current"
+                  max={<Trans>Current</Trans>}
                   onChange={setExodPriceInput}
                   onMax={() => setExodPriceInput(marketPrice)}
                 />
 
                 <FieldInput
-                  fieldName="Future EXOD market price ($)"
+                  field={<Trans>Future EXOD market price ($)</Trans>}
                   value={Number(finalExodPriceInput.toFixed(2))}
-                  maxName="Current"
+                  max={<Trans>Current</Trans>}
                   onChange={setFinalExodPriceInput}
                   onMax={() => setFinalExodPriceInput(marketPrice)}
                 />
@@ -205,31 +205,31 @@ export default () => (
 );
 
 type FieldInputProps = {
-  fieldName: string;
+  field: any;
   value: number;
   onChange: (value: number) => void;
-  maxName: string;
+  max: any;
   onMax: (value: any) => void;
 };
 
-const FieldInput = ({ fieldName, value, onChange, maxName, onMax }: FieldInputProps) => {
+const FieldInput = ({ field, value, onChange, max, onMax }: FieldInputProps) => {
   return (
     <CalcRow>
       <Typography variant="h6" color="textSecondary">
-        {fieldName}
+        {field}
       </Typography>
       <FormControl variant="outlined" color="primary">
         <InputLabel htmlFor="amount-input"></InputLabel>
         <OutlinedInput
           type="number"
-          placeholder={`Enter ${fieldName}`}
+          placeholder={`${(<Trans>Enter</Trans>)} ${field}`}
           value={value || null}
           onChange={e => onChange(Number(e.target.value))}
           labelWidth={0}
           endAdornment={
             <InputAdornment position="end">
               <Button variant="text" onClick={onMax} color="inherit">
-                {maxName}
+                {max}
               </Button>
             </InputAdornment>
           }
@@ -251,10 +251,11 @@ const SliderHeader = ({
   return (
     <SliderHeaderContainer onClick={!!currentRunway ? onClick : undefined} runwayLoaded={!!currentRunway}>
       <Typography variant="h6" color="textSecondary">
-        {calcDays} Days
+        {calcDays} <Trans>Days</Trans>
       </Typography>
       <Typography variant="h6" color="textSecondary">
-        Current runway: {currentRunway ? `${currentRunway?.toFixed(2)} Days` : "Loading..."}
+        <Trans>Current runway:</Trans>{" "}
+        {currentRunway ? `${currentRunway?.toFixed(2)} ${(<Trans>Days</Trans>)}` : <Trans>Loading...</Trans>}
       </Typography>
     </SliderHeaderContainer>
   );

--- a/src/views/Calc/Calc.tsx
+++ b/src/views/Calc/Calc.tsx
@@ -111,21 +111,21 @@ function Calc() {
               <ImportantValues {...{ marketPrice, stakingRebase, isAppLoading, trimmedBalance }} />
               <CalcArea>
                 <FieldInput
-                  field={<Trans>sEXOD Amount</Trans>}
+                  field={t`sEXOD Amount`}
                   value={exodAmountInput}
                   max={<Trans>Max</Trans>}
                   onChange={setExodAmountInput}
                   onMax={() => setExodAmountInput(trimmedBalance)}
                 />
                 <FieldInput
-                  field={<Trans>Rebase rate</Trans>}
+                  field={t`Rebase rate`}
                   value={Number(rebaseRateInput.toFixed(4))}
                   max={<Trans>Current</Trans>}
                   onChange={setRebaseRateInput}
                   onMax={() => setRebaseRateInput(stakingRebase * 100)}
                 />
                 <FieldInput
-                  field={<Trans>EXOD price at purchase ($)</Trans>}
+                  field={t`EXOD price at purchase ($)`}
                   value={Number(exodPriceInput.toFixed(2))}
                   max={<Trans>Current</Trans>}
                   onChange={setExodPriceInput}
@@ -133,7 +133,7 @@ function Calc() {
                 />
 
                 <FieldInput
-                  field={<Trans>Future EXOD market price ($)</Trans>}
+                  field={t`Future EXOD market price ($)`}
                   value={Number(finalExodPriceInput.toFixed(2))}
                   max={<Trans>Current</Trans>}
                   onChange={setFinalExodPriceInput}
@@ -224,7 +224,7 @@ const FieldInput = ({ field, value, onChange, max, onMax }: FieldInputProps) => 
         <InputLabel htmlFor="amount-input"></InputLabel>
         <OutlinedInput
           type="number"
-          placeholder={`${(<Trans>Enter</Trans>)} ${field}`}
+          placeholder={`${t`Enter`} ${field}`}
           value={value || null}
           onChange={e => onChange(Number(e.target.value))}
           labelWidth={0}

--- a/src/views/Calc/Calc.tsx
+++ b/src/views/Calc/Calc.tsx
@@ -12,7 +12,7 @@ import {
   Slider,
 } from "@material-ui/core";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { Trans } from "@lingui/macro";
+import { Trans, t } from "@lingui/macro";
 import { useAppSelector } from "src/hooks";
 import styled from "styled-components";
 import CalcHeader from "./CalcHeader";
@@ -171,7 +171,9 @@ function Calc() {
                 totalReturns={totalReturns}
               />
               <YugiQuote>
-                <Typography variant="subtitle2">My grandpa's deck has no pathetic cards, Kaiba 🃏</Typography>
+                <Typography variant="subtitle2">
+                  <Trans>My grandpa's deck has no pathetic cards, Kaiba</Trans> 🃏
+                </Typography>
               </YugiQuote>
             </Grid>
           </Paper>
@@ -255,7 +257,7 @@ const SliderHeader = ({
       </Typography>
       <Typography variant="h6" color="textSecondary">
         <Trans>Current runway:</Trans>{" "}
-        {currentRunway ? `${currentRunway?.toFixed(2)} ${(<Trans>Days</Trans>)}` : <Trans>Loading...</Trans>}
+        {currentRunway ? `${currentRunway?.toFixed(2)} ${t`Days`}` : <Trans>Loading...</Trans>}
       </Typography>
     </SliderHeaderContainer>
   );

--- a/src/views/Calc/Calc.tsx
+++ b/src/views/Calc/Calc.tsx
@@ -33,7 +33,7 @@ import {
 import { useTreasuryMetrics } from "../TreasuryDashboard/hooks/useTreasuryMetrics";
 
 function Calc() {
-  const [exodAmountInput, setExodAmountInput] = useState(0);
+  const [exodAmountInput, setExodAmountInput] = useState(1);
   const [rebaseRateInput, setRebaseRateInput] = useState(0);
   const [exodPriceInput, setExodPriceInput] = useState(0);
   const [finalExodPriceInput, setFinalExodPriceInput] = useState(0);
@@ -67,7 +67,7 @@ function Calc() {
   );
 
   useEffect(() => {
-    setExodAmountInput(trimmedBalance);
+    trimmedBalance && setExodAmountInput(trimmedBalance);
   }, [trimmedBalance]);
 
   useEffect(() => {
@@ -188,6 +188,7 @@ function Calc() {
               rebaseRate={rebaseRateInput}
               finalExodPrice={finalExodPriceInput}
               exodPrice={exodPriceInput}
+              stakingView={false}
             />
           </Paper>
         </Zoom>

--- a/src/views/Calc/Calc.tsx
+++ b/src/views/Calc/Calc.tsx
@@ -19,7 +19,7 @@ import CalcHeader from "./CalcHeader";
 import ImportantValues from "./ImportantValues";
 import EstimatedValues from "./EstimatedValues";
 import PriceMultiplier from "./PriceMultiplier";
-import CalcChart from "./CalcChart";
+import PersonalExodChart from "src/components/Chart/PersonalExodChart";
 import {
   calcInitialInvestment,
   calcMinimumDays,
@@ -182,12 +182,12 @@ function Calc() {
       <CalcContainer>
         <Zoom in={true}>
           <Paper className="ohm-card">
-            <CalcChart
+            <PersonalExodChart
               calcDays={calcDays}
-              exodAmountInput={exodAmountInput}
-              rebaseRateInput={rebaseRateInput}
-              finalExodPriceInput={finalExodPriceInput}
-              exodPriceInput={exodPriceInput}
+              exodAmount={exodAmountInput}
+              rebaseRate={rebaseRateInput}
+              finalExodPrice={finalExodPriceInput}
+              exodPrice={exodPriceInput}
             />
           </Paper>
         </Zoom>

--- a/src/views/Calc/Calc.tsx
+++ b/src/views/Calc/Calc.tsx
@@ -19,6 +19,7 @@ import CalcHeader from "./CalcHeader";
 import ImportantValues from "./ImportantValues";
 import EstimatedValues from "./EstimatedValues";
 import PriceMultiplier from "./PriceMultiplier";
+import CalcChart from "./CalcChart";
 import {
   calcInitialInvestment,
   calcMinimumDays,
@@ -101,80 +102,95 @@ function Calc() {
   }, [initialInvestment, rebaseRateInput, calcDays, exodAmountInput]);
 
   return (
-    <CalcContainer id="stake-view">
-      <Zoom in={true}>
-        <Paper className="ohm-card">
-          <Grid container direction="column" spacing={2}>
-            <CalcHeader />
-            <ImportantValues {...{ marketPrice, stakingRebase, isAppLoading, trimmedBalance }} />
-            <CalcArea>
-              <FieldInput
-                fieldName="sEXOD Amount"
-                value={exodAmountInput}
-                maxName="Max"
-                onChange={setExodAmountInput}
-                onMax={() => setExodAmountInput(trimmedBalance)}
-              />
-              <FieldInput
-                fieldName="Rebase rate"
-                value={Number(rebaseRateInput.toFixed(4))}
-                maxName="Current"
-                onChange={setRebaseRateInput}
-                onMax={() => setRebaseRateInput(stakingRebase * 100)}
-              />
-              <FieldInput
-                fieldName="EXOD price at purchase ($)"
-                value={Number(exodPriceInput.toFixed(2))}
-                maxName="Current"
-                onChange={setExodPriceInput}
-                onMax={() => setExodPriceInput(marketPrice)}
-              />
+    <>
+      <CalcContainer id="stake-view">
+        <Zoom in={true}>
+          <Paper className="ohm-card">
+            <Grid container direction="column" spacing={2}>
+              <CalcHeader />
+              <ImportantValues {...{ marketPrice, stakingRebase, isAppLoading, trimmedBalance }} />
+              <CalcArea>
+                <FieldInput
+                  fieldName="sEXOD Amount"
+                  value={exodAmountInput}
+                  maxName="Max"
+                  onChange={setExodAmountInput}
+                  onMax={() => setExodAmountInput(trimmedBalance)}
+                />
+                <FieldInput
+                  fieldName="Rebase rate"
+                  value={Number(rebaseRateInput.toFixed(4))}
+                  maxName="Current"
+                  onChange={setRebaseRateInput}
+                  onMax={() => setRebaseRateInput(stakingRebase * 100)}
+                />
+                <FieldInput
+                  fieldName="EXOD price at purchase ($)"
+                  value={Number(exodPriceInput.toFixed(2))}
+                  maxName="Current"
+                  onChange={setExodPriceInput}
+                  onMax={() => setExodPriceInput(marketPrice)}
+                />
 
-              <FieldInput
-                fieldName="Future EXOD market price ($)"
-                value={Number(finalExodPriceInput.toFixed(2))}
-                maxName="Current"
-                onChange={setFinalExodPriceInput}
-                onMax={() => setFinalExodPriceInput(marketPrice)}
+                <FieldInput
+                  fieldName="Future EXOD market price ($)"
+                  value={Number(finalExodPriceInput.toFixed(2))}
+                  maxName="Current"
+                  onChange={setFinalExodPriceInput}
+                  onMax={() => setFinalExodPriceInput(marketPrice)}
+                />
+              </CalcArea>
+              <SliderArea>
+                <CalcRow>
+                  <SliderContainer>
+                    <SliderHeader
+                      currentRunway={currentRunway}
+                      calcDays={calcDays}
+                      onClick={() => setCalcDays(Math.floor(Number(currentRunway)))}
+                    />
+                    <Slider
+                      aria-label="Days"
+                      max={365}
+                      value={calcDays}
+                      color="primary"
+                      onChange={(_e, newValue) => setCalcDays(Number(newValue))}
+                    />
+                  </SliderContainer>
+                </CalcRow>
+                <CalcRow>
+                  <PriceMultiplier currentPrice={marketPrice} setFinalExodPriceInput={setFinalExodPriceInput} />
+                </CalcRow>
+              </SliderArea>
+              <EstimatedValues
+                initialInvestment={initialInvestment}
+                estimatedROI={calcRoi(totalReturns, initialInvestment)}
+                totalSExod={calcTotalExod(exodAmountInput, yieldPercent)}
+                estimatedProfits={calcProfits(totalReturns, initialInvestment)}
+                breakEvenDays={minimumDays}
+                minimumPrice={minimumPrice}
+                totalReturns={totalReturns}
               />
-            </CalcArea>
-            <SliderArea>
-              <CalcRow>
-                <SliderContainer>
-                  <SliderHeader
-                    currentRunway={currentRunway}
-                    calcDays={calcDays}
-                    onClick={() => setCalcDays(Math.floor(Number(currentRunway)))}
-                  />
-                  <Slider
-                    aria-label="Days"
-                    max={365}
-                    value={calcDays}
-                    color="primary"
-                    onChange={(_e, newValue) => setCalcDays(Number(newValue))}
-                  />
-                </SliderContainer>
-              </CalcRow>
-              <CalcRow>
-                <PriceMultiplier currentPrice={marketPrice} setFinalExodPriceInput={setFinalExodPriceInput} />
-              </CalcRow>
-            </SliderArea>
-            <EstimatedValues
-              initialInvestment={initialInvestment}
-              estimatedROI={calcRoi(totalReturns, initialInvestment)}
-              totalSExod={calcTotalExod(exodAmountInput, yieldPercent)}
-              estimatedProfits={calcProfits(totalReturns, initialInvestment)}
-              breakEvenDays={minimumDays}
-              minimumPrice={minimumPrice}
-              totalReturns={totalReturns}
+              <YugiQuote>
+                <Typography variant="subtitle2">My grandpa's deck has no pathetic cards, Kaiba 🃏</Typography>
+              </YugiQuote>
+            </Grid>
+          </Paper>
+        </Zoom>
+      </CalcContainer>
+      <CalcContainer>
+        <Zoom in={true}>
+          <Paper className="ohm-card">
+            <CalcChart
+              calcDays={calcDays}
+              exodAmountInput={exodAmountInput}
+              rebaseRateInput={rebaseRateInput}
+              finalExodPriceInput={finalExodPriceInput}
+              exodPriceInput={exodPriceInput}
             />
-            <YugiQuote>
-              <Typography variant="subtitle2">My grandpa's deck has no pathetic cards, Kaiba 🃏</Typography>
-            </YugiQuote>
-          </Grid>
-        </Paper>
-      </Zoom>
-    </CalcContainer>
+          </Paper>
+        </Zoom>
+      </CalcContainer>
+    </>
   );
 }
 

--- a/src/views/Calc/CalcChart.tsx
+++ b/src/views/Calc/CalcChart.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from "react";
+import { useTheme } from "@material-ui/core/styles";
+import Chart from "src/components/Chart/Chart";
+import { darkTheme } from "src/themes/dark.js";
+import { calcYieldPercent, calcTotalReturns, calcTotalExod } from "./formulas";
+import styled from "styled-components";
+
+type CalcChartProps = {
+  calcDays: number;
+  exodAmountInput: number;
+  rebaseRateInput: number;
+  finalExodPriceInput: number;
+  exodPriceInput: number;
+};
+
+const infoTooltipMessage =
+  "Your projected staked EXOD balance over time. You can use this to estimate the growth of your sEXOD balance.";
+
+const usdTooltip =
+  "Your projected USD balance over time. Price increases/decreases by the same percentage each day to finally reach the target price.";
+
+const CalcChart = ({
+  calcDays,
+  exodAmountInput,
+  rebaseRateInput,
+  finalExodPriceInput,
+  exodPriceInput,
+}: CalcChartProps) => {
+  const theme = useTheme();
+  const [mode, setMode] = useState("sEXOD");
+  const data =
+    mode === "sEXOD"
+      ? calcSExodChart(calcDays, exodAmountInput, rebaseRateInput)
+      : calcUsdChart(calcDays, exodAmountInput, rebaseRateInput, finalExodPriceInput, exodPriceInput);
+
+  const switchMode = () => {
+    setMode(mode === "sEXOD" ? "USD" : "sEXOD");
+  };
+
+  return (
+    <Chart
+      type="line"
+      data={data}
+      dataKey={[mode]}
+      headerText={[`${mode} over time`]}
+      headerSubText={<SwitchToUSD onClick={switchMode}>Switch to {mode === "sEXOD" ? "USD" : "sEXOD"}</SwitchToUSD>}
+      itemNames={[mode]}
+      todayMessage=""
+      itemType=""
+      color={darkTheme.gold}
+      stroke={[darkTheme.gold]}
+      infoTooltipMessage={mode === "sEXOD" ? infoTooltipMessage : usdTooltip}
+      expandedGraphStrokeColor={theme.palette.graphStrokeColor}
+      xInterval={30}
+      bulletpointColors={[
+        {
+          right: 20,
+          top: -12,
+          background: darkTheme.gold,
+        },
+      ]}
+    />
+  );
+};
+
+export default CalcChart;
+
+const calcSExodChart = (calcDays: number, exodAmountInput: number, rebaseRateInput: number) => {
+  const data = [];
+
+  for (let day = 0; day < calcDays; day++) {
+    const yeildPercent = calcYieldPercent(rebaseRateInput, day);
+    const sEXOD = calcTotalExod(exodAmountInput, yeildPercent);
+    data.unshift({ sEXOD, timestamp: nowPlusDays(day) });
+  }
+  return data;
+};
+
+const calcUsdChart = (
+  calcDays: number,
+  exodAmountInput: number,
+  rebaseRateInput: number,
+  finalExodPriceInput: number,
+  exodPriceInput: number,
+) => {
+  const data = [];
+
+  // Instead of linear change in price per day, price changes by same percentage each day to reach final price.
+  const changePerDay = Math.pow(finalExodPriceInput / exodPriceInput, 1 / calcDays) - 1;
+  let price = exodPriceInput;
+
+  for (let day = 0; day < calcDays; day++) {
+    const yeildPercent = calcYieldPercent(rebaseRateInput, day);
+    const sEXOD = calcTotalExod(exodAmountInput, yeildPercent);
+    const USD = sEXOD * price;
+    price = price + price * changePerDay;
+
+    data.unshift({ USD, timestamp: nowPlusDays(day) });
+  }
+  return data;
+};
+
+const nowPlusDays = (days: number) => {
+  return Date.now() / 1000 + 86400 * days;
+};
+
+const SwitchToUSD = styled.div`
+  cursor: pointer;
+`;

--- a/src/views/Calc/CalcHeader.tsx
+++ b/src/views/Calc/CalcHeader.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { Grid, Typography } from "@material-ui/core";
 import styled from "styled-components";
+import { Trans } from "@lingui/macro";
 
 const CalcHeader = () => {
   return (
     <Grid item>
       <Heading variant="h5">OBLITERATOR (🧪 + 🧪 = ❔)</Heading>
-      <Typography variant="body1">Estimate your returns</Typography>
+      <Typography variant="body1">
+        <Trans>Estimate your returns</Trans>
+      </Typography>
     </Grid>
   );
 };

--- a/src/views/Calc/CalcHeader.tsx
+++ b/src/views/Calc/CalcHeader.tsx
@@ -6,7 +6,9 @@ import { Trans } from "@lingui/macro";
 const CalcHeader = () => {
   return (
     <Grid item>
-      <Heading variant="h5">OBLITERATOR (🧪 + 🧪 = ❔)</Heading>
+      <Heading variant="h5">
+        <Trans>OBLITERATOR</Trans> (🧪 + 🧪 = ❔)
+      </Heading>
       <Typography variant="body1">
         <Trans>Estimate your returns</Trans>
       </Typography>

--- a/src/views/Calc/EstimatedValues.tsx
+++ b/src/views/Calc/EstimatedValues.tsx
@@ -26,7 +26,7 @@ const EstimatedValues = ({
     <>
       <EstimationColumn>
         <FieldValue
-          fieldName="Initial investment"
+          field={<Trans>Initial investment</Trans>}
           value={new Intl.NumberFormat("en-US", {
             style: "currency",
             currency: "USD",
@@ -35,10 +35,10 @@ const EstimatedValues = ({
           }).format(initialInvestment)}
         />
         <div />
-        <FieldValue fieldName="Estimated ROI" value={`${estimatedROI ? estimatedROI.toFixed(2) : 0}x`} />
-        <FieldValue fieldName="Total sEXOD" value={`${totalSExod.toFixed(2)}`} />
+        <FieldValue field={<Trans>Estimated ROI</Trans>} value={`${estimatedROI ? estimatedROI.toFixed(2) : 0}x`} />
+        <FieldValue field={<Trans>Total sEXOD</Trans>} value={`${totalSExod.toFixed(2)}`} />
         <FieldValue
-          fieldName="Estimated profits"
+          field={<Trans>Estimated profits</Trans>}
           value={new Intl.NumberFormat("en-US", {
             style: "currency",
             currency: "USD",
@@ -47,7 +47,7 @@ const EstimatedValues = ({
           }).format(estimatedProfits)}
         />
         <FieldValue
-          fieldName="Total returns"
+          field={<Trans>Total returns</Trans>}
           value={new Intl.NumberFormat("en-US", {
             style: "currency",
             currency: "USD",
@@ -58,7 +58,7 @@ const EstimatedValues = ({
       </EstimationColumn>
       <EstimationColumn>
         <FieldValue
-          fieldName="Break even price"
+          field={<Trans>Break even price</Trans>}
           value={new Intl.NumberFormat("en-US", {
             style: "currency",
             currency: "USD",
@@ -66,7 +66,7 @@ const EstimatedValues = ({
             minimumFractionDigits: 2,
           }).format(minimumPrice || 0)}
         />
-        <FieldValue fieldName="Days to break even" value={`${breakEvenDays}`} />
+        <FieldValue field={<Trans>Days to break even</Trans>} value={`${breakEvenDays}`} />
       </EstimationColumn>
     </>
   );
@@ -74,11 +74,11 @@ const EstimatedValues = ({
 
 export default EstimatedValues;
 
-const FieldValue = ({ fieldName, value }: { fieldName: string; value: string }) => {
+const FieldValue = ({ field, value }: { field: any; value: string }) => {
   return (
     <EstimationRow>
       <Typography variant="h6" color="textSecondary">
-        {fieldName}
+        {field}
       </Typography>
       <Typography variant="h6" color="textPrimary">
         {value}

--- a/src/views/Calc/ImportantValues.tsx
+++ b/src/views/Calc/ImportantValues.tsx
@@ -19,9 +19,17 @@ const ImportantValues = ({ marketPrice, stakingRebase, isAppLoading, trimmedBala
   return (
     <Grid item>
       <Grid container spacing={2} alignItems="flex-end">
-        <FieldValue value={`$${trim(marketPrice, 2)}`} field="EXOD Price" isAppLoading={isAppLoading} />
-        <FieldValue value={`${stakingRebasePercentage}%`} field="Current Rebase Rate" isAppLoading={isAppLoading} />
-        <FieldValue value={`${trimmedBalance} ${sOHM_TICKER}`} field="Your sEXOD Balance" isAppLoading={isAppLoading} />
+        <FieldValue value={`$${trim(marketPrice, 2)}`} field={<Trans>EXOD Price</Trans>} isAppLoading={isAppLoading} />
+        <FieldValue
+          value={`${stakingRebasePercentage}%`}
+          field={<Trans>Current Rebase Rate</Trans>}
+          isAppLoading={isAppLoading}
+        />
+        <FieldValue
+          value={`${trimmedBalance} ${sOHM_TICKER}`}
+          field={<Trans>Your sEXOD Balance</Trans>}
+          isAppLoading={isAppLoading}
+        />
       </Grid>
     </Grid>
   );
@@ -29,7 +37,7 @@ const ImportantValues = ({ marketPrice, stakingRebase, isAppLoading, trimmedBala
 
 export default ImportantValues;
 
-const FieldValue = ({ field, value, isAppLoading }: { field: string; value: any; isAppLoading: boolean }) => {
+const FieldValue = ({ field, value, isAppLoading }: { field: any; value: any; isAppLoading: boolean }) => {
   return (
     <Grid item xs={12} sm={4} md={4} lg={4}>
       <FieldContainer>

--- a/src/views/Calc/PriceMultiplier.tsx
+++ b/src/views/Calc/PriceMultiplier.tsx
@@ -1,21 +1,6 @@
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
-import {
-  Button,
-  FormControl,
-  Grid,
-  InputAdornment,
-  InputLabel,
-  OutlinedInput,
-  Paper,
-  Typography,
-  Zoom,
-  Slider,
-  Radio,
-  RadioGroup,
-  FormControlLabel,
-  FormLabel,
-} from "@material-ui/core";
+import { OutlinedInput, Typography, Radio, RadioGroup, FormControlLabel } from "@material-ui/core";
 import { Trans } from "@lingui/macro";
 
 const PriceMultiplier = ({
@@ -50,7 +35,7 @@ const PriceMultiplier = ({
         </RadioGroup>
         <OutlinedInput
           type="number"
-          placeholder={`Custom...`}
+          placeholder={<Trans>Custom...</Trans>}
           value={multiplier || null}
           onChange={e => setMultiplier(Number(e.target.value) || null)}
           labelWidth={0}

--- a/src/views/Calc/PriceMultiplier.tsx
+++ b/src/views/Calc/PriceMultiplier.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { OutlinedInput, Typography, Radio, RadioGroup, FormControlLabel } from "@material-ui/core";
-import { Trans } from "@lingui/macro";
+import { Trans, t } from "@lingui/macro";
 
 const PriceMultiplier = ({
   currentPrice,
@@ -35,7 +35,7 @@ const PriceMultiplier = ({
         </RadioGroup>
         <OutlinedInput
           type="number"
-          placeholder={<Trans>Custom...</Trans>}
+          placeholder={t`Custom...`}
           value={multiplier || null}
           onChange={e => setMultiplier(Number(e.target.value) || null)}
           labelWidth={0}

--- a/src/views/ChooseBond/ClaimBonds.jsx
+++ b/src/views/ChooseBond/ClaimBonds.jsx
@@ -119,7 +119,7 @@ function ClaimBonds({ activeBonds }) {
                       <TxnButtonTextGeneralPending
                         pendingTransactions={pendingTransactions}
                         type="redeem_all_bonds"
-                        defaultText="Claim all"
+                        defaultText={<Trans>Claim all</Trans>}
                       />
                     </Button>
 
@@ -137,7 +137,7 @@ function ClaimBonds({ activeBonds }) {
                       <TxnButtonTextGeneralPending
                         pendingTransactions={pendingTransactions}
                         type="redeem_all_bonds_autostake"
-                        defaultText="Claim all and Stake"
+                        defaultText={<Trans>Claim all and Stake</Trans>}
                       />
                     </Button>
                   </>

--- a/src/views/ChooseBond/ClaimRow.jsx
+++ b/src/views/ChooseBond/ClaimRow.jsx
@@ -69,7 +69,7 @@ export function ClaimBondTableData({ userBond }) {
             <TxnButtonTextGeneralPending
               pendingTransactions={pendingTransactions}
               type={"redeem_bond_" + bondName}
-              defaultText="Claim"
+              defaultText={<Trans>Claim</Trans>}
             />
           </Typography>
         </Button>
@@ -138,7 +138,7 @@ export function ClaimBondCardData({ userBond }) {
             <TxnButtonTextGeneralPending
               pendingTransactions={pendingTransactions}
               type={"redeem_bond_" + bondName}
-              defaultText="Claim"
+              defaultText={<Trans>Claim</Trans>}
             />
           </Typography>
         </Button>
@@ -147,7 +147,7 @@ export function ClaimBondCardData({ userBond }) {
             <TxnButtonTextGeneralPending
               pendingTransactions={pendingTransactions}
               type={"redeem_bond_" + bondName + "_autostake"}
-              defaultText="Claim and Stake"
+              defaultText={<Trans>Claim and Stake</Trans>}
             />
           </Typography>
         </Button>

--- a/src/views/Stake/Stake.tsx
+++ b/src/views/Stake/Stake.tsx
@@ -16,6 +16,7 @@ import {
   Zoom,
   Divider,
 } from "@material-ui/core";
+import styled from "styled-components";
 import { t, Trans } from "@lingui/macro";
 import NewReleases from "@material-ui/icons/NewReleases";
 import RebaseTimer from "../../components/RebaseTimer/RebaseTimer";
@@ -31,6 +32,7 @@ import { error } from "../../slices/MessagesSlice";
 import { ethers } from "ethers";
 import { OHM_TICKER, sOHM_TICKER } from "../../constants";
 import { useAppSelector } from "src/hooks";
+import PersonalExodChart from "../../components/Chart/PersonalExodChart";
 
 function a11yProps(index: number) {
   return {
@@ -51,6 +53,7 @@ function Stake() {
   const [quantity, setQuantity] = useState(0);
 
   const isAppLoading = useAppSelector(state => state.app.loading);
+  const marketPrice = useAppSelector(state => state.app.marketPrice || 0);
   const currentIndex = useAppSelector(state => {
     return state.app.currentIndex;
   });
@@ -476,8 +479,31 @@ function Stake() {
           </Grid>
         </Paper>
       </Zoom>
+      <ChartContainer>
+        <Zoom in={true}>
+          <Paper className="ohm-card">
+            <PersonalExodChart
+              calcDays={90}
+              exodAmount={(trimmedBalance || 0) + (quantity || trim(Number(ohmBalance), 4) || 0)}
+              rebaseRate={stakingRebase * 100}
+              finalExodPrice={marketPrice}
+              exodPrice={marketPrice}
+              stakingView
+            />
+          </Paper>
+        </Zoom>
+      </ChartContainer>
     </div>
   );
 }
 
 export default Stake;
+
+const ChartContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  width: 100%;
+`;

--- a/src/views/Stake/Stake.tsx
+++ b/src/views/Stake/Stake.tsx
@@ -503,7 +503,7 @@ function Stake() {
           <Paper className="ohm-card">
             <PersonalExodChart
               calcDays={90}
-              exodAmount={(trimmedBalance || 0) + (quantity || trim(Number(ohmBalance), 4) || 0)}
+              exodAmount={(trimmedBalance || 0) + (quantity || Number(ohmBalance) || 0)}
               rebaseRate={stakingRebase * 100}
               finalExodPrice={marketPrice}
               exodPrice={marketPrice}

--- a/src/views/Stake/Stake.tsx
+++ b/src/views/Stake/Stake.tsx
@@ -327,7 +327,7 @@ function Stake() {
                               <TxnButtonText
                                 pendingTransactions={pendingTransactions}
                                 type="staking"
-                                defaultText={`Stake ${OHM_TICKER}`}
+                                defaultText={<Trans>Stake {OHM_TICKER}</Trans>}
                               />
                             </Button>
                           </Box>
@@ -345,7 +345,7 @@ function Stake() {
                               <TxnButtonText
                                 pendingTransactions={pendingTransactions}
                                 type="approve_staking"
-                                defaultText="Approve"
+                                defaultText={<Trans>Approve</Trans>}
                               />
                             </Button>
                           </Box>
@@ -368,7 +368,7 @@ function Stake() {
                               <TxnButtonText
                                 pendingTransactions={pendingTransactions}
                                 type="unstaking"
-                                defaultText={`Unstake ${OHM_TICKER}`}
+                                defaultText={<Trans>Unstake {OHM_TICKER}</Trans>}
                               />
                             </Button>
                           </Box>
@@ -386,7 +386,7 @@ function Stake() {
                               <TxnButtonText
                                 pendingTransactions={pendingTransactions}
                                 type="approve_unstaking"
-                                defaultText="Approve"
+                                defaultText={<Trans>Approve</Trans>}
                               />
                             </Button>
                           </Box>

--- a/src/views/Stake/Stake.tsx
+++ b/src/views/Stake/Stake.tsx
@@ -428,6 +428,25 @@ function Stake() {
                         )}
                       </Typography>
                     </div>
+                    <div className="data-row">
+                      <Typography variant="body1">
+                        <Trans>Staked Balance Value ($)</Trans>
+                      </Typography>
+                      <Typography variant="body1" id="user-staked-balance">
+                        {isAppLoading ? (
+                          <Skeleton width="80px" />
+                        ) : (
+                          <>
+                            {new Intl.NumberFormat("en-US", {
+                              style: "currency",
+                              currency: "USD",
+                              maximumFractionDigits: 2,
+                              minimumFractionDigits: 2,
+                            }).format(marketPrice * trimmedBalance)}
+                          </>
+                        )}
+                      </Typography>
+                    </div>
 
                     {/*                    <div className="data-row" style={{ paddingLeft: "10px" }}>
                       <Typography variant="body2" color="textSecondary">

--- a/src/views/TreasuryDashboard/components/Graph/Graph.js
+++ b/src/views/TreasuryDashboard/components/Graph/Graph.js
@@ -41,15 +41,18 @@ export const MarketValueGraph = () => {
   const ethDatalength = ethData && ethData.length;
 
   for (let i = 0; i < datalength - ethDatalength; i++) {
-    ethData && ethData.push({ sOHMBalanceUSD: 0 })
+    ethData && ethData.push({ sOHMBalanceUSD: 0 });
   }
   console.log(ethData);
-  console.log(data)
-  const stats = ethData && data && data.map((e, i) => ({
-    timestamp: e.id,
-    ...e,
-    sOHMBalanceUSD: ethData[i].sOHMBalanceUSD,
-  }))
+  console.log(data);
+  const stats =
+    ethData &&
+    data &&
+    data.map((e, i) => ({
+      timestamp: e.id,
+      ...e,
+      sOHMBalanceUSD: ethData[i].sOHMBalanceUSD,
+    }));
 
   return (
     <Chart
@@ -161,12 +164,11 @@ export const APYOverTimeGraph = () => {
 
   const apy =
     data &&
-    data
-      .map(entry => ({
-        timestamp: entry.timestamp,
-        apy: (Math.pow(parseFloat(entry.percentage) + 1, 365 * 3) * 100),
-      }))
-  
+    data.map(entry => ({
+      timestamp: entry.timestamp,
+      apy: Math.pow(parseFloat(entry.percentage) + 1, 365 * 3) * 100,
+    }));
+
   return (
     <Chart
       type="line"
@@ -181,7 +183,7 @@ export const APYOverTimeGraph = () => {
       bulletpointColors={bulletpoints.apy}
       stroke={[theme.palette.text.primary]}
       infoTooltipMessage={tooltipInfoMessages.apy}
-      headerSubText={`${apy && (apy[0].apy).toLocaleString("en-us")}%`}
+      headerSubText={`${apy && apy[0].apy.toLocaleString("en-us")}%`}
       expandedGraphStrokeColor={theme.palette.graphStrokeColor}
     />
   );
@@ -222,12 +224,11 @@ export const DilutionGraph = () => {
 
   const dilution =
     data &&
-    data
-      .map(entry => ({
-        timestamp: entry.timestamp,
-        percentage: (entry.index / (entry.ohmCirculatingSupply / 2000)) * 100, //initial total supply of 2000
-        wsExodPrice: entry.index  * entry.ohmPrice,
-      }))
+    data.map(entry => ({
+      timestamp: entry.timestamp,
+      percentage: (entry.index / (entry.ohmCirculatingSupply / 2000)) * 100, //initial total supply of 2000
+      wsExodPrice: entry.index * entry.ohmPrice,
+    }));
 
   return (
     <Chart
@@ -245,7 +246,7 @@ export const DilutionGraph = () => {
       expandedGraphStrokeColor={theme.palette.graphStrokeColor}
     />
   );
-}
+};
 
 export const OhmMintedGraph = () => {
   const theme = useTheme();
@@ -258,13 +259,13 @@ export const OhmMintedGraph = () => {
         timestamp: entry.timestamp,
         ohmMinted: entry.ohmMinted,
       }))
-      .slice(0, data.length-1)
+      .slice(0, data.length - 1);
 
   const fiveDaySlice = minted && minted.slice(0, 5);
   //react-query is so weird why won't it let me use .reduce() T_T
   let fiveDayTotal = 0;
   for (let i = 0; i < 5; i++) {
-    fiveDayTotal += fiveDaySlice && fiveDaySlice[i].ohmMinted
+    fiveDayTotal += fiveDaySlice && fiveDaySlice[i].ohmMinted;
   }
   return (
     <Chart
@@ -280,9 +281,10 @@ export const OhmMintedGraph = () => {
       infoTooltipMessage={tooltipInfoMessages.minted}
       expandedGraphStrokeColor={theme.palette.graphStrokeColor}
       headerSubText={`${(fiveDayTotal && fiveDayTotal / 5).toFixed(2)} EXOD`}
+      todayMessage="5-day Average"
     />
   );
-}
+};
 
 export const OhmMintedPerTotalSupplyGraph = () => {
   const theme = useTheme();
@@ -315,9 +317,10 @@ export const OhmMintedPerTotalSupplyGraph = () => {
       infoTooltipMessage={tooltipInfoMessages.mcs}
       expandedGraphStrokeColor={theme.palette.graphStrokeColor}
       headerSubText={`${(fiveDayTotal && fiveDayTotal / 5).toFixed(2)}%`}
+      todayMessage="5-day Average"
     />
   );
-}
+};
 
 export const DebtRatioGraph = () => {
   const theme = useTheme();
@@ -325,13 +328,12 @@ export const DebtRatioGraph = () => {
 
   const debtRatios =
     data &&
-    data
-      .map(entry => ({
-        timestamp: entry.timestamp,
-        daiDebtRatio: entry.dai_debt_ratio / 1e10,
-        ethDebtRatio: entry.eth_debt_ratio / 1e10,
-        ohmDaiDebtRatio: entry.ohmdai_debt_ratio / 1e19,
-      }))
+    data.map(entry => ({
+      timestamp: entry.timestamp,
+      daiDebtRatio: entry.dai_debt_ratio / 1e10,
+      ethDebtRatio: entry.eth_debt_ratio / 1e10,
+      ohmDaiDebtRatio: entry.ohmdai_debt_ratio / 1e19,
+    }));
   const [current, ...others] = bulletpoints.runway;
   const runwayBulletpoints = [{ ...current, background: theme.palette.text.primary }, ...others];
   const colors = runwayBulletpoints.map(b => b.background);
@@ -344,7 +346,9 @@ export const DebtRatioGraph = () => {
       color={theme.palette.text.primary}
       stroke={colors}
       headerText="Debt Ratios"
-      headerSubText={`Total ${debtRatios && trim(debtRatios[0].daiDebtRatio + debtRatios[0].ethDebtRatio + debtRatios[0].ohmDaiDebtRatio, 2)}%`}
+      headerSubText={`Total ${
+        debtRatios && trim(debtRatios[0].daiDebtRatio + debtRatios[0].ethDebtRatio + debtRatios[0].ohmDaiDebtRatio, 2)
+      }%`}
       dataFormat="percent"
       bulletpointColors={runwayBulletpoints}
       itemNames={tooltipItems.debtratio}
@@ -354,4 +358,4 @@ export const DebtRatioGraph = () => {
       isDebt={true}
     />
   );
-}
+};

--- a/src/views/TreasuryDashboard/treasuryData.ts
+++ b/src/views/TreasuryDashboard/treasuryData.ts
@@ -194,16 +194,16 @@ export const bulletpoints = {
 
 export const tooltipItems = {
   tvl: [t`Total Value Deposited`],
-  coin: [t`DAI", "wFTM", "sOHM`],
+  coin: [t`DAI`, t`wFTM`, t`sOHM`],
   rfv: [t`DAI`],
   holder: [t`Exodians`],
   apy: [t`APY`],
-  runway: [t`Current", "7.5K APY", "5K APY", "2.5K APY`],
-  pol: [t`spLP Treasury", "Market spLP`],
-  dilution: [t`Dilution Percentage", "wsEXOD Price`],
+  runway: [t`Current`, t`7.5K APY`, t`5K APY`, t`2.5K APY`],
+  pol: [t`spLP Treasury`, t`Market spLP`],
+  dilution: [t`Dilution Percentage`, t`wsEXOD Price`],
   minted: [t`EXOD minted`],
   mcs: [t`EXOD Minted/Total Supply`],
-  debtratio: [t`DAI Debt Ratio", "ETH Debt Ratio", "OHM-DAI spLP Debt Ratio`],
+  debtratio: [t`DAI Debt Ratio`, t`wFTM Debt Ratio`, t`EXOD-DAI spLP Debt Ratio`],
 };
 
 export const tooltipInfoMessages = {

--- a/src/views/TreasuryDashboard/treasuryData.ts
+++ b/src/views/TreasuryDashboard/treasuryData.ts
@@ -1,3 +1,5 @@
+import { t } from "@lingui/macro";
+
 // TODO: add paramaterization
 export const treasuryDataQuery = `
 query {
@@ -187,40 +189,40 @@ export const bulletpoints = {
       top: -12,
       background: "linear-gradient(180deg, #55EBC7 -10%, #47ACEB 100%)",
     },
-  ]
+  ],
 };
 
 export const tooltipItems = {
-  tvl: ["Total Value Deposited"],
-  coin: ["DAI", "wFTM", "sOHM"],
-  rfv: ["DAI"],
-  holder: ["Exodians"],
-  apy: ["APY"],
-  runway: ["Current", "7.5K APY", "5K APY", "2.5K APY"],
-  pol: ["spLP Treasury", "Market spLP"],
-  dilution: ["Dilution Percentage", "wsEXOD Price"],
-  minted: ["EXOD minted"],
-  mcs: ["EXOD Minted/Total Supply"],
-  debtratio: ["DAI Debt Ratio", "ETH Debt Ratio", "OHM-DAI spLP Debt Ratio"]
+  tvl: [t`Total Value Deposited`],
+  coin: [t`DAI", "wFTM", "sOHM`],
+  rfv: [t`DAI`],
+  holder: [t`Exodians`],
+  apy: [t`APY`],
+  runway: [t`Current", "7.5K APY", "5K APY", "2.5K APY`],
+  pol: [t`spLP Treasury", "Market spLP`],
+  dilution: [t`Dilution Percentage", "wsEXOD Price`],
+  minted: [t`EXOD minted`],
+  mcs: [t`EXOD Minted/Total Supply`],
+  debtratio: [t`DAI Debt Ratio", "ETH Debt Ratio", "OHM-DAI spLP Debt Ratio`],
 };
 
 export const tooltipInfoMessages = {
-  tvl: "Total Value Deposited, is the dollar amount of all EXOD staked in the protocol. This metric is often used as growth or health indicator in DeFi projects.",
-  mvt: "Market Value of Treasury Assets, is the sum of the value (in dollars) of all assets held by the treasury.",
-  rfv: "Risk Free Value, is the amount of funds the treasury guarantees to use for backing EXOD.",
-  pol: "Protocol Owned Liquidity, is the amount of LP the treasury owns and controls. The more POL the better for the protocol and its users.",
-  holder: "Holders, represents the total number of Exodians (sEXOD holders)",
-  staked: "EXOD Staked, is the ratio of sEXOD to EXOD (staked vs unstaked)",
-  apy: "Annual Percentage Yield, is the normalized representation of an interest rate, based on a compounding period over one year. Note that APYs provided are rather ballpark level indicators and not so much precise future results.",
-  runway: "Runway, is the number of days sEXOD emissions can be sustained at a given rate. Lower APY = longer runway",
-  dilution: "Dilution, is the ratio between index growth and total supply growth. It indicates how much stakers have been diluted. Slower decline is better.",
-  minted: "EXOD Minted, is the number of EXOD minted each day from bonds",
-  mcs: "EXOD minted/Total Supply, is the number of EXOD minted from bonds over total supply of EXOD.",
-  debtratio: "Debt ratio, is a metric that tells you how much EXOD is currently vesting in relation to the total EXOD supply. The numbers dont reflect the actual values, but, it can be used to form an impression of how much EXOD is being minted from bonding in relation to the total supply.",
+  tvl: t`Total Value Deposited, is the dollar amount of all EXOD staked in the protocol. This metric is often used as growth or health indicator in DeFi projects.`,
+  mvt: t`Market Value of Treasury Assets, is the sum of the value (in dollars) of all assets held by the treasury.`,
+  rfv: t`Risk Free Value, is the amount of funds the treasury guarantees to use for backing EXOD.`,
+  pol: t`Protocol Owned Liquidity, is the amount of LP the treasury owns and controls. The more POL the better for the protocol and its users.`,
+  holder: t`Holders, represents the total number of Exodians (sEXOD holders)`,
+  staked: t`EXOD Staked, is the ratio of sEXOD to EXOD (staked vs unstaked)`,
+  apy: t`Annual Percentage Yield, is the normalized representation of an interest rate, based on a compounding period over one year. Note that APYs provided are rather ballpark level indicators and not so much precise future results.`,
+  runway: t`Runway, is the number of days sEXOD emissions can be sustained at a given rate. Lower APY = longer runway`,
+  dilution: t`Dilution, is the ratio between index growth and total supply growth. It indicates how much stakers have been diluted. Slower decline is better.`,
+  minted: t`EXOD Minted, is the number of EXOD minted each day from bonds`,
+  mcs: t`EXOD minted/Total Supply, is the number of EXOD minted from bonds over total supply of EXOD.`,
+  debtratio: t`Debt ratio, is a metric that tells you how much EXOD is currently vesting in relation to the total EXOD supply. The numbers dont reflect the actual values, but, it can be used to form an impression of how much EXOD is being minted from bonding in relation to the total supply.`,
 };
 
 export const itemType = {
   dollar: "$",
   percentage: "%",
-  OHM: "EXOD"
+  OHM: "EXOD",
 };

--- a/src/views/Wrap/Wrap.jsx
+++ b/src/views/Wrap/Wrap.jsx
@@ -287,7 +287,7 @@ function Wrap() {
                             <TxnButtonText
                               pendingTransactions={pendingTransactions}
                               type="wrapping"
-                              defaultText="Wrap sOHM"
+                              defaultText={<Trans>Wrap sOHM</Trans>}
                             />
                           </Button>
                         ) : (
@@ -303,7 +303,7 @@ function Wrap() {
                             <TxnButtonText
                               pendingTransactions={pendingTransactions}
                               type="approve_wrapping"
-                              defaultText="Approve"
+                              defaultText={<Trans>Approve</Trans>}
                             />
                           </Button>
                         )}
@@ -322,7 +322,7 @@ function Wrap() {
                           <TxnButtonText
                             pendingTransactions={pendingTransactions}
                             type="unwrapping"
-                            defaultText="Unwrap sOHM"
+                            defaultText={<Trans>Unwrap sOHM</Trans>}
                           />
                         </Button>
                       </TabPanel>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,13 +4,16 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "esModuleInterop": true,
-    "lib": ["ESNext", "dom"],
+    "lib": [
+      "ESNext",
+      "dom"
+    ],
     "module": "ESNext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "sourceMap": true,
     "target": "es2017",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "baseUrl": ".",
     "skipLibCheck": true,
     "allowJs": true,
@@ -21,7 +24,17 @@
     "noEmit": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["./index.d.ts", "src", "babel.config.js"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx", "node_modules", "vendor", "public"],
+  "include": [
+    "./index.d.ts",
+    "src",
+    "babel.config.js"
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "node_modules",
+    "vendor",
+    "public"
+  ],
   "compileOnSave": false
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,16 +4,13 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "esModuleInterop": true,
-    "lib": [
-      "ESNext",
-      "dom"
-    ],
+    "lib": ["ESNext", "dom"],
     "module": "ESNext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "sourceMap": true,
     "target": "es2017",
-    "jsx": "react-jsx",
+    "jsx": "react",
     "baseUrl": ".",
     "skipLibCheck": true,
     "allowJs": true,
@@ -24,17 +21,7 @@
     "noEmit": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": [
-    "./index.d.ts",
-    "src",
-    "babel.config.js"
-  ],
-  "exclude": [
-    "**/*.test.ts",
-    "**/*.test.tsx",
-    "node_modules",
-    "vendor",
-    "public"
-  ],
+  "include": ["./index.d.ts", "src", "babel.config.js"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "node_modules", "vendor", "public"],
   "compileOnSave": false
 }


### PR DESCRIPTION
## NOTE
The translations submodule version needs to be updated here before merging. Just waiting on [this PR](https://github.com/ExodiaFinance/exodia-translations/pull/1) to be merged.
## Changes
- de-init the olympus translations repo
- init the exodia translation repo
- Add <Trans> tags correctly for: 
  - Entire calculator page
  - New links added to the sidenav since original fork
  - Stake/Bond/Claim etc buttons (Adding the loading spinner broke the translations)
  - 1 or 2 other areas
- Add a chart below the calculator which you can view in USD or sEXOD.
  - User can toggle the chart view (sEXOD vs USD value)
  - Chart shows the growth of your sEXOD overtime given the parameters
  - Chart shows the growth/decline of your USD overtime given the parameters
    - USD is calculated by assuming a same % increase/decrease in USD value of EXOD to move from initial price to final price. This is explained in a tooltip.
- Add the same chart to the staked page using the users staked balance + (unstaked || input amount) and the current USD price
  - Default to USD value while the chart on the calculator defaults to sEXOD value.
  - Default to 1 sEXOD if user has no amount (staked, unsttaked, input)
- Add the users current staked value in USD to the staked page


### Example of translations working and calculator chart (English below)
![Screenshot from 2021-12-05 21-55-00](https://user-images.githubusercontent.com/86249394/144749420-18bcb970-171b-4cf0-8db2-3ff542101e4d.png)
## Chart
![Screenshot from 2021-12-05 21-54-41](https://user-images.githubusercontent.com/86249394/144749427-829a4906-c8e0-491e-bd32-74687c711956.png)
## Staked value USD
![Screenshot from 2021-12-05 22-01-16](https://user-images.githubusercontent.com/86249394/144749668-e951d95f-5d86-411e-a283-cd184ba7a27b.png)
![Screenshot from 2021-12-05 22-29-32](https://user-images.githubusercontent.com/86249394/144750824-8cf423a6-5bc3-4353-9d4e-4d47b3b63be0.png)

