### PR TITLE
Updated treasury MV chart, apy numbers, runway chart, calc formulas

### DIFF
--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -397,11 +397,11 @@ const renderComposedChart = (
       orientation="right"
       axisLine={false}
       tickLine={false}
-      tickCount={isExpanded ? expandedTickCount : tickCount}
+      tickCount={3}
       width={33}
-      domain={[0, "auto"]}
+      domain={["dataMin", "dataMax"]}
       allowDataOverflow={false}
-      tickFormatter={number => (number !== 0 ? `$${number}` : "")}
+      tickFormatter={number => (number !== 0 ? `${number}` : "")}
     />
     <Tooltip
       // formatter={value => trim(parseFloat(value), 2)}

--- a/src/slices/AppSlice.ts
+++ b/src/slices/AppSlice.ts
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import { addresses } from "../constants";
+import { addresses, BLOCK_RATE_SECONDS, EPOCH_INTERVAL } from "../constants";
 import { abi as OlympusStakingv2ABI } from "../abi/OlympusStakingv2.json";
 import { abi as sOHMv2 } from "../abi/sOhmv2.json";
 import { setAll, getTokenPrice, getMarketPrice } from "../helpers";
@@ -101,12 +101,14 @@ export const loadAppDetails = createAsyncThunk(
     ) as SOhmv2;
 
     // Calculating staking
+    const nRebasesFiveDays = 86400 * 5 / (BLOCK_RATE_SECONDS * EPOCH_INTERVAL);
+    const nRebasesYear = 86400 * 365 / (BLOCK_RATE_SECONDS * EPOCH_INTERVAL);
     const epoch = await stakingContract.epoch();
     const stakingReward = epoch.distribute;
     const circ = await sohmMainContract.circulatingSupply();
     const stakingRebase = Number(stakingReward.toString()) / Number(circ.toString());
-    const fiveDayRate = Math.pow(1 + stakingRebase, 5 * 3) - 1;
-    const stakingAPY = Math.pow(1 + stakingRebase, 365 * 3) - 1;
+    const fiveDayRate = Math.pow(1 + stakingRebase, nRebasesFiveDays) - 1;
+    const stakingAPY = Math.pow(1 + stakingRebase, nRebasesYear) - 1;
     const endBlock = epoch.endBlock;
 
     // Current index

--- a/src/views/Calc/Calc.tsx
+++ b/src/views/Calc/Calc.tsx
@@ -31,6 +31,7 @@ import {
   calcTotalExod,
 } from "./formulas";
 import { useTreasuryMetrics } from "../TreasuryDashboard/hooks/useTreasuryMetrics";
+import { BLOCK_RATE_SECONDS, EPOCH_INTERVAL } from "src/constants";
 
 function Calc() {
   const [exodAmountInput, setExodAmountInput] = useState(1);
@@ -56,7 +57,7 @@ function Calc() {
   const { data } = useTreasuryMetrics({ refetchOnMount: false });
 
   const runway = data && data.filter((metric: any) => metric.runway10k > 5);
-  const currentRunway = runway && runway[0].runwayCurrent;
+  const currentRunway = runway && (runway[0].runwayCurrent * 3 * EPOCH_INTERVAL * BLOCK_RATE_SECONDS) / 86400 ;
 
   const trimmedBalance = Number(
     [sohmBalance, wsohmAsSohm]

--- a/src/views/Calc/formulas.ts
+++ b/src/views/Calc/formulas.ts
@@ -1,5 +1,8 @@
+import { BLOCK_RATE_SECONDS, EPOCH_INTERVAL } from "src/constants";
+
 export const calcYieldPercent = (rebaseRate: number, days: number) => {
-  return Math.pow(1 + rebaseRate / 100, days * 3);
+  const nRebases = 86400 * days / (BLOCK_RATE_SECONDS * EPOCH_INTERVAL)
+  return Math.pow(1 + rebaseRate / 100, nRebases);
 };
 
 export const calcTotalReturns = (exodAmount: number, finalExodPrice: number, yieldPercent: number): number => {
@@ -16,9 +19,8 @@ export const calcMinimumDays = (
   finalExodPrice: number,
   rebaseRate: number,
 ): number => {
-  const minDays = Math.ceil(
-    Math.log(initialInvestment / (exodAmount * finalExodPrice)) / Math.log(1 + rebaseRate / 100) / 3,
-  );
+  const minRebases = Math.log(initialInvestment / (exodAmount * finalExodPrice)) / Math.log(1 + rebaseRate / 100);
+  const minDays = Math.ceil((minRebases * EPOCH_INTERVAL * BLOCK_RATE_SECONDS) / 86400);
   return minDays > 0 ? minDays : 0;
 };
 
@@ -28,7 +30,8 @@ export const calcMinimumPrice = (
   calcDays: number,
   exodAmount: number,
 ): number => {
-  return initialInvestment / (Math.pow(1 + rebaseRate / 100, 3 * calcDays) * exodAmount);
+  const nRebases = 86400 * calcDays / (BLOCK_RATE_SECONDS * EPOCH_INTERVAL);
+  return initialInvestment / (Math.pow(1 + rebaseRate / 100, nRebases) * exodAmount);
 };
 
 export const calcRoi = (totalReturns: number, initialInvestment: number): number => {

--- a/src/views/ChooseBond/ChooseBond.tsx
+++ b/src/views/ChooseBond/ChooseBond.tsx
@@ -29,6 +29,7 @@ import { IUserBondDetails } from "src/slices/AccountSlice";
 import { DebtRatioGraph, OhmMintedGraph, OhmMintedPerTotalSupplyGraph } from "../TreasuryDashboard/components/Graph/Graph";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { useTreasuryOhm } from "../TreasuryDashboard/hooks/useTreasuryOhm";
+import styled from "styled-components";
 
 function ChooseBond() {
   const { chainID } = useWeb3Context();
@@ -53,7 +54,7 @@ function ChooseBond() {
     return state.app.marketPrice;
   });
 
-  const {data: ethTreasury} = useTreasuryOhm({refetchOnMount: false});
+  const { data: ethTreasury } = useTreasuryOhm({ refetchOnMount: false });
 
   const treasuryBalance: number | undefined = useAppSelector(state => {
     if (state.bonding.loading == false) {
@@ -71,116 +72,124 @@ function ChooseBond() {
   return (
     <div id="choose-bond-view">
       {!isAccountLoading && !isEmpty(accountBonds) && <ClaimBonds activeBonds={accountBonds} />}
-
-      <Zoom in={true}>
-        <Paper className="ohm-card">
-          <Box className="card-header">
-            <Typography variant="h5" data-testid="t">
-              <Trans>Bond</Trans> (1,1)
-            </Typography>
-          </Box>
-
-          <Grid container item xs={12} style={{ margin: "10px 0px 20px" }} className="bond-hero">
-            <Grid item xs={6}>
-              <Box textAlign={`${isVerySmallScreen ? "left" : "center"}`}>
-                <Typography variant="h5" color="textSecondary">
-                  <Trans>Treasury Balance</Trans>
-                </Typography>
-                <Box>
-                  {isAppLoading ? (
-                    <Skeleton width="180px" data-testid="treasury-balance-loading" />
-                  ) : (
-                    <Typography variant="h4" data-testid="treasury-balance">
-                      {new Intl.NumberFormat("en-US", {
-                        style: "currency",
-                        currency: "USD",
-                        maximumFractionDigits: 0,
-                        minimumFractionDigits: 0,
-                      }).format(Number(treasuryBalance))}
-                    </Typography>
-                  )}
+      <BondContainer>
+        <Zoom in={true}>
+          <Grid container spacing={3}>
+            <Grid item xs={12}>
+              <Paper className="ohm-card full-width">
+                <Box className="card-header">
+                  <Typography variant="h5" data-testid="t">
+                    <Trans>Bond</Trans> (1,1)
+                  </Typography>
                 </Box>
+
+                <Grid container item xs={12} style={{ margin: "10px 0px 20px" }} className="bond-hero">
+                  <Grid item xs={6}>
+                    <Box textAlign={`${isVerySmallScreen ? "left" : "center"}`}>
+                      <Typography variant="h5" color="textSecondary">
+                        <Trans>Treasury Balance</Trans>
+                      </Typography>
+                      <Box>
+                        {isAppLoading ? (
+                          <Skeleton width="180px" data-testid="treasury-balance-loading" />
+                        ) : (
+                          <Typography variant="h4" data-testid="treasury-balance">
+                            {new Intl.NumberFormat("en-US", {
+                              style: "currency",
+                              currency: "USD",
+                              maximumFractionDigits: 0,
+                              minimumFractionDigits: 0,
+                            }).format(Number(treasuryBalance))}
+                          </Typography>
+                        )}
+                      </Box>
+                    </Box>
+                  </Grid>
+
+                  <Grid item xs={6} className={`ohm-price`}>
+                    <Box textAlign={`${isVerySmallScreen ? "right" : "center"}`}>
+                      <Typography variant="h5" color="textSecondary">
+                        <Trans>EXOD Price</Trans>
+                      </Typography>
+                      <Typography variant="h4">
+                        {isAppLoading ? <Skeleton width="100px" /> : formatCurrency(Number(marketPrice), 2)}
+                      </Typography>
+                    </Box>
+                  </Grid>
+                </Grid>
+
+                {!isSmallScreen && (
+                  <Grid container item>
+                    <TableContainer>
+                      <Table aria-label="Available bonds">
+                        <TableHead>
+                          <TableRow>
+                            <TableCell align="center">
+                              <Trans>Bond</Trans>
+                            </TableCell>
+                            <TableCell align="left">
+                              <Trans>Price</Trans>
+                            </TableCell>
+                            <TableCell align="left">
+                              <Trans>ROI</Trans>
+                            </TableCell>
+                            <TableCell align="right">
+                              <Trans>Purchased</Trans>
+                            </TableCell>
+                            <TableCell align="right"></TableCell>
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {bonds.map(bond => (
+                            <BondTableData key={bond.name} bond={bond} />
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </TableContainer>
+                  </Grid>
+                )}
+              </Paper>
+            </Grid>
+
+            {isSmallScreen && (
+              <Box className="ohm-card-container" marginY="8px" width="100%">
+                <Grid container item spacing={3}>
+                  {bonds.map(bond => (
+                    <Grid item xs={12} key={bond.name}>
+                      <BondDataCard key={bond.name} bond={bond} />
+                    </Grid>
+                  ))}
+                </Grid>
               </Box>
-            </Grid>
+            )}
 
-            <Grid item xs={6} className={`ohm-price`}>
-              <Box textAlign={`${isVerySmallScreen ? "right" : "center"}`}>
-                <Typography variant="h5" color="textSecondary">
-                  <Trans>EXOD Price</Trans>
-                </Typography>
-                <Typography variant="h4">
-                  {isAppLoading ? <Skeleton width="100px" /> : formatCurrency(Number(marketPrice), 2)}
-                </Typography>
-              </Box>
+            <Grid item lg={6} md={6} sm={12} xs={12}>
+              <Paper className="ohm-card full-width">
+                <OhmMintedGraph />
+              </Paper>
+            </Grid>
+            <Grid item lg={6} md={6} sm={12} xs={12}>
+              <Paper className="ohm-card full-width">
+                <OhmMintedPerTotalSupplyGraph />
+              </Paper>
+            </Grid>
+            <Grid item xs={12}>
+              <Paper className="ohm-card full-width">
+                <DebtRatioGraph />
+              </Paper>
             </Grid>
           </Grid>
-
-          {!isSmallScreen && (
-            <Grid container item>
-              <TableContainer>
-                <Table aria-label="Available bonds">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell align="center">
-                        <Trans>Bond</Trans>
-                      </TableCell>
-                      <TableCell align="left">
-                        <Trans>Price</Trans>
-                      </TableCell>
-                      <TableCell align="left">
-                        <Trans>ROI</Trans>
-                      </TableCell>
-                      <TableCell align="right">
-                        <Trans>Purchased</Trans>
-                      </TableCell>
-                      <TableCell align="right"></TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {bonds.map(bond => (
-                      <BondTableData key={bond.name} bond={bond} />
-                    ))}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-            </Grid>
-          )}
-        </Paper>
-      </Zoom>
-      {isSmallScreen && (
-        <Box className="ohm-card-container">
-          <Grid container item spacing={2}>
-            {bonds.map(bond => (
-              <Grid item xs={12} key={bond.name}>
-                <BondDataCard key={bond.name} bond={bond} />
-              </Grid>
-            ))}
-          </Grid>
-        </Box>
-      )}
-
-      <Zoom in={true}>
-        <Grid container item spacing={2} className="ohm-card">
-          <Grid item lg={6} md={6} sm={12} xs={12}>
-            <Paper className="ohm-card ohm-card-graph">
-              <OhmMintedGraph />
-            </Paper>
-          </Grid>
-          <Grid item lg={6} md={6} sm={12} xs={12}>
-            <Paper className="ohm-card ohm-card-graph">
-              <OhmMintedPerTotalSupplyGraph />
-            </Paper>
-          </Grid>
-          <Grid item xs={12}>
-            <Paper className="ohm-card ohm-card-graph">
-              <DebtRatioGraph />
-            </Paper>
-          </Grid>
-        </Grid>
-      </Zoom>
+        </Zoom>
+      </BondContainer>
     </div>
   );
 }
+
+const BondContainer = styled.div`
+  max-width: 833px;
+  width: 100%;
+  padding: 1rem;
+`;
 
 
 const queryClient = new QueryClient();

--- a/src/views/ChooseBond/choosebond.scss
+++ b/src/views/ChooseBond/choosebond.scss
@@ -6,26 +6,18 @@
   overflow: hidden;
   .ohm-card .bond-hero h4 {
     font-weight: 600 !important;
-
+    
     .MuiSkeleton-root {
       margin: auto;
     }
   }
-  .ohm-card-graph {
-    max-width: unset !important;
+
+  .ohm-card{
+    margin-bottom: 0px;
+  }
+
+  .full-width {
     width: 100%;
-    margin: auto;
-    max-height: 355px;
-    .card-header {
-      margin-bottom: 1rem;
-    }
-    &.ohm-chart-card {
-      .chart-card-header {
-        padding: 0px 20px !important;
-        min-width: 300px;
-      }
-      height: 355px;
-    }
   }
 
   .claim-bonds-card {

--- a/src/views/TreasuryDashboard/TreasuryDashboard.tsx
+++ b/src/views/TreasuryDashboard/TreasuryDashboard.tsx
@@ -108,12 +108,11 @@ const TreasuryDashboard = memo(() => {
               </Paper>
             </Grid>
 
-            {/* temporarily removed until better price action */}
-            {/* <Grid item xs={12}>
+            <Grid item xs={12}>
               <Paper className="ohm-card">
                 <DilutionGraph />
               </Paper>
-            </Grid> */}
+            </Grid>
           </Grid>
         </Zoom>
       </Container>

--- a/src/views/TreasuryDashboard/components/Graph/Graph.js
+++ b/src/views/TreasuryDashboard/components/Graph/Graph.js
@@ -231,7 +231,7 @@ export const DilutionGraph = () => {
     data.map(entry => ({
       timestamp: entry.timestamp,
       percentage: (entry.index / (entry.ohmCirculatingSupply / 2000)) * 100, //initial total supply of 2000
-      wsExodPrice: entry.index * entry.ohmPrice,
+      wsExodPrice: entry.index
     }));
 
   return (

--- a/src/views/TreasuryDashboard/components/Graph/Graph.js
+++ b/src/views/TreasuryDashboard/components/Graph/Graph.js
@@ -350,7 +350,8 @@ export const DebtRatioGraph = () => {
       color={theme.palette.text.primary}
       stroke={colors}
       headerText="Debt Ratios"
-      headerSubText={`Total ${debtRatios && trim(debtRatios[0].daiDebtRatio + debtRatios[0].ethDebtRatio + debtRatios[0].ohmDaiDebtRatio, 2)
+      headerSubText={`Total ${
+          debtRatios && trim(debtRatios[0].daiDebtRatio + debtRatios[0].ethDebtRatio + debtRatios[0].ohmDaiDebtRatio, 2)
         }%`}
       dataFormat="percent"
       bulletpointColors={runwayBulletpoints}

--- a/src/views/TreasuryDashboard/components/Graph/Graph.js
+++ b/src/views/TreasuryDashboard/components/Graph/Graph.js
@@ -5,7 +5,7 @@ import { useTreasuryMetrics } from "../../hooks/useTreasuryMetrics";
 import { useTreasuryRebases } from "../../hooks/useTreasuryRebases";
 import { useDebtMetrics } from "../../hooks/useDebtMetrics";
 import { bulletpoints, tooltipItems, tooltipInfoMessages, itemType } from "../../treasuryData";
-import { OHM_TICKER } from "../../../../constants";
+import { EPOCH_INTERVAL, OHM_TICKER } from "../../../../constants";
 import { useTreasuryOhm } from "../../hooks/useTreasuryOhm";
 import { parse } from "date-fns";
 
@@ -197,7 +197,16 @@ export const RunwayAvailableGraph = () => {
   const theme = useTheme();
   const { data } = useTreasuryMetrics({ refetchOnMount: false });
 
-  const runway = data && data.filter(metric => metric.runway10k > 5);
+  const runway =
+    data && 
+    data.map(entry => {
+      const epochLengthSeconds = EPOCH_INTERVAL * 0.9;
+      return {
+        timestamp: entry.timestamp,
+        runwayCurrent: (entry.runwayCurrent * 3 * epochLengthSeconds) / 86400, //86400 is number of seconds in a day.
+        runway7dot5k: (entry.runway7dot5k * 3 * epochLengthSeconds) / 86400,
+      }
+    })
 
   const [current, ...others] = bulletpoints.runway;
   const runwayBulletpoints = [{ ...current, background: theme.palette.text.primary }, ...others];
@@ -211,7 +220,7 @@ export const RunwayAvailableGraph = () => {
       color={theme.palette.text.primary}
       stroke={colors}
       headerText="Runway Available"
-      headerSubText={`${data && trim(data[0].runwayCurrent, 1)} Days`}
+      headerSubText={`${runway && trim(runway[0].runwayCurrent, 1)} Days`}
       dataFormat="days"
       bulletpointColors={runwayBulletpoints}
       itemNames={tooltipItems.runway}
@@ -231,21 +240,21 @@ export const DilutionGraph = () => {
     data.map(entry => ({
       timestamp: entry.timestamp,
       percentage: (entry.index / (entry.ohmCirculatingSupply / 2000)) * 100, //initial total supply of 2000
-      wsExodPrice: entry.index
+      index: entry.index
     }));
 
   return (
     <Chart
       type="composed"
       data={dilution}
-      dataKey={["percentage", "wsExodPrice"]}
+      dataKey={["percentage", "index"]}
       stopColor={[["#F5AC37", "#EA9276"]]}
       stroke={"#38caff"}
       headerText="Dilution Over Time"
       headerSubText={`${dilution && trim(dilution[0].percentage, 2)}%`}
       bulletpointColors={bulletpoints.dilution}
       itemNames={tooltipItems.dilution}
-      itemType={[itemType.percentage, itemType.dollar]}
+      itemType={[itemType.percentage, "sEXOD"]}
       infoTooltipMessage={tooltipInfoMessages.dilution}
       expandedGraphStrokeColor={theme.palette.graphStrokeColor}
     />

--- a/src/views/TreasuryDashboard/components/Graph/Graph.js
+++ b/src/views/TreasuryDashboard/components/Graph/Graph.js
@@ -43,16 +43,20 @@ export const MarketValueGraph = () => {
   for (let i = 0; i < datalength - ethDatalength; i++) {
     ethData && ethData.push({ sOHMBalanceUSD: 0 });
   }
-  console.log(ethData);
-  console.log(data);
+
   const stats =
     ethData &&
     data &&
-    data.map((e, i) => ({
+    data.map((e, i) => {
+    const gOhmPrice = ethData[i].gOhmPrice ? ethData[i].gOhmPrice : 0;
+    const gOhmBalance = e.treasuryGOhmBalance ? e.treasuryGOhmBalance : 0;
+    const sOHMBalanceUSD = ethData[i].sOHMBalanceUSD + (gOhmBalance * gOhmPrice)
+    return {
       timestamp: e.id,
       ...e,
-      sOHMBalanceUSD: ethData[i].sOHMBalanceUSD,
-    }));
+      sOHMBalanceUSD,
+    }
+  })
 
   return (
     <Chart
@@ -346,9 +350,8 @@ export const DebtRatioGraph = () => {
       color={theme.palette.text.primary}
       stroke={colors}
       headerText="Debt Ratios"
-      headerSubText={`Total ${
-        debtRatios && trim(debtRatios[0].daiDebtRatio + debtRatios[0].ethDebtRatio + debtRatios[0].ohmDaiDebtRatio, 2)
-      }%`}
+      headerSubText={`Total ${debtRatios && trim(debtRatios[0].daiDebtRatio + debtRatios[0].ethDebtRatio + debtRatios[0].ohmDaiDebtRatio, 2)
+        }%`}
       dataFormat="percent"
       bulletpointColors={runwayBulletpoints}
       itemNames={tooltipItems.debtratio}

--- a/src/views/TreasuryDashboard/treasuryData.ts
+++ b/src/views/TreasuryDashboard/treasuryData.ts
@@ -202,7 +202,7 @@ export const tooltipItems = {
   apy: [t`APY`],
   runway: [t`Current`, t`7.5K APY`, t`5K APY`, t`2.5K APY`],
   pol: [t`spLP Treasury`, t`Market spLP`],
-  dilution: [t`Dilution Percentage`, t`wsEXOD Price`],
+  dilution: [t`Dilution Percentage`, t`Current Index`],
   minted: [t`EXOD minted`],
   mcs: [t`EXOD Minted/Total Supply`],
   debtratio: [t`DAI Debt Ratio`, t`wFTM Debt Ratio`, t`EXOD-DAI spLP Debt Ratio`],

--- a/src/views/TreasuryDashboard/treasuryData.ts
+++ b/src/views/TreasuryDashboard/treasuryData.ts
@@ -19,6 +19,7 @@ query {
     treasuryDaiRiskFreeValue
     treasuryDaiMarketValue
     treasuryWETHMarketValue
+    treasuryGOhmBalance
     currentAPY
     runway10k
     runway20k
@@ -48,6 +49,7 @@ export const treasuryOhmQuery = `
 query {
   balances(first: 100, orderBy: timestamp, orderDirection: desc) {
     sOHMBalanceUSD
+    gOhmPrice
   }
 }
 `;

--- a/src/views/TreasuryDashboard/treasuryData.ts
+++ b/src/views/TreasuryDashboard/treasuryData.ts
@@ -196,7 +196,7 @@ export const bulletpoints = {
 
 export const tooltipItems = {
   tvl: [t`Total Value Deposited`],
-  coin: [t`DAI`, t`wFTM`, t`sOHM`],
+  coin: [t`DAI`, t`wFTM`, t`gOHM`],
   rfv: [t`DAI`],
   holder: [t`Exodians`],
   apy: [t`APY`],


### PR DESCRIPTION
### Changes
- Updated treasury market value chart to include gOHM in fantom network treasury
- Fixed padding consistency in bond page
- Uncommented dilution graph and changed it from dilution vs wsExod price to dilution vs index
- updated apy numbers across the website to reflect actual values based on 0.9sec block time (was assumed to be 1sec before)