### PR TITLE
[EXOD-019] Ensure balances and approvals are updated after transactions

### DIFF
--- a/src/slices/AppSlice.ts
+++ b/src/slices/AppSlice.ts
@@ -62,7 +62,7 @@ export const loadAppDetails = createAsyncThunk(
     const stakingAPY = Math.pow(1 + stakingRebase, nRebasesYear) - 1;
     const endBlock = epoch.endBlock;
 
-    // console.log(blockRateSeconds);
+    console.log(`Fantom Block Rate: ${blockRateSeconds} seconds`);
     return {
       currentIndex: ethers.utils.formatUnits(currentIndex, "gwei"),
       currentBlock,

--- a/src/slices/BondSlice.ts
+++ b/src/slices/BondSlice.ts
@@ -60,7 +60,6 @@ export const changeApproval = createAsyncThunk(
             field: "allowance",
             stateAccessor: `account.bonds[${bond.name}].allowance`,
             thunkToCall: () => dispatch(calculateUserBondDetails({ address, bond, networkID, provider })),
-            clearPendingTxs: () => dispatch(clearPendingTxn(approveTx.hash)),
           }),
         );
       }

--- a/src/slices/BondSlice.ts
+++ b/src/slices/BondSlice.ts
@@ -1,6 +1,7 @@
 import { ethers, BigNumber, BigNumberish } from "ethers";
 import { contractForRedeemHelper } from "../helpers";
 import { getBalances, calculateUserBondDetails } from "./AccountSlice";
+import { pollUpdateState, pollManyUpdateState, PollUpdateStateParams } from "./PollStateUpdateSlice";
 import { findOrLoadMarketPrice } from "./AppSlice";
 import { error, info } from "./MessagesSlice";
 import { clearPendingTxn, fetchPendingTxns } from "./PendingTxnsSlice";
@@ -30,7 +31,7 @@ export const changeApproval = createAsyncThunk(
     const reserveContract = bond.getContractForReserve(networkID, signer);
     const bondAddr = bond.getAddressForBond(networkID);
 
-    let approveTx;
+    let approveTx: any;
     let bondAllowance = await reserveContract.allowance(address, bondAddr);
 
     // return early if approval already exists
@@ -54,8 +55,14 @@ export const changeApproval = createAsyncThunk(
       dispatch(error((e as IJsonRPCError).message));
     } finally {
       if (approveTx) {
-        dispatch(clearPendingTxn(approveTx.hash));
-        dispatch(calculateUserBondDetails({ address, bond, networkID, provider }));
+        dispatch(
+          pollUpdateState({
+            field: "allowance",
+            stateAccessor: `account.bonds[${bond.name}].allowance`,
+            thunkToCall: () => dispatch(calculateUserBondDetails({ address, bond, networkID, provider })),
+            clearPendingTxs: () => dispatch(clearPendingTxn(approveTx.hash)),
+          }),
+        );
       }
     }
   },
@@ -209,9 +216,14 @@ export const bondAsset = createAsyncThunk(
       );
       uaData.txHash = bondTx.hash;
       await bondTx.wait();
-      // UX preference (show pending after txn complete or after balance updated)
 
-      dispatch(calculateUserBondDetails({ address, bond, networkID, provider }));
+      dispatch(
+        pollUpdateState({
+          field: "interestDue",
+          stateAccessor: `account.bonds[${bond.name}].interestDue`,
+          thunkToCall: () => dispatch(calculateUserBondDetails({ address, bond, networkID, provider })),
+        }),
+      );
     } catch (e: unknown) {
       const rpcError = e as IJsonRPCError;
       if (rpcError.code === -32603 && rpcError.message.indexOf("ds-math-sub-underflow") >= 0) {
@@ -267,13 +279,21 @@ export const redeemBond = createAsyncThunk(
       }
     }
 
-    try {
-      await dispatch(calculateUserBondDetails({ address, bond, networkID, provider }));
-    } catch (e) {
-      console.error((e as IJsonRPCError).message);
-    }
+    const statesToPoll: Array<PollUpdateStateParams> = [];
 
-    dispatch(getBalances({ address, networkID, provider }));
+    statesToPoll.push({
+      field: "interestDue",
+      stateAccessor: `account.bonds[${bond.name}].interestDue`,
+      thunkToCall: () => dispatch(calculateUserBondDetails({ address, bond, networkID, provider })),
+    });
+
+    statesToPoll.push({
+      field: `balances.${autostake ? "sohm" : "ohm"}`,
+      stateAccessor: `account.balances.${autostake ? "sohm" : "ohm"}`,
+      thunkToCall: () => dispatch(getBalances({ address, networkID, provider })),
+    });
+
+    dispatch(pollManyUpdateState({ statesToPoll }));
   },
 );
 
@@ -308,16 +328,23 @@ export const redeemAllBonds = createAsyncThunk(
       }
     }
 
+    const statesToPoll: Array<PollUpdateStateParams> = [];
     bonds &&
       bonds.forEach(async bond => {
-        try {
-          dispatch(calculateUserBondDetails({ address, bond, networkID, provider }));
-        } catch (e) {
-          console.error((e as IJsonRPCError).message);
-        }
+        statesToPoll.push({
+          field: "interestDue",
+          stateAccessor: `account.bonds[${bond.name}].interestDue`,
+          thunkToCall: () => dispatch(calculateUserBondDetails({ address, bond, networkID, provider })),
+        });
       });
 
-    dispatch(getBalances({ address, networkID, provider }));
+    statesToPoll.push({
+      field: `balances.${autostake ? "sohm" : "ohm"}`,
+      stateAccessor: `account.balances.${autostake ? "sohm" : "ohm"}`,
+      thunkToCall: () => dispatch(getBalances({ address, networkID, provider })),
+    });
+
+    dispatch(pollManyUpdateState({ statesToPoll }));
   },
 );
 

--- a/src/slices/PollStateUpdateSlice.ts
+++ b/src/slices/PollStateUpdateSlice.ts
@@ -1,0 +1,86 @@
+import { BigNumber, BigNumberish, ethers } from "ethers";
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import _ from "lodash";
+import { info, error } from "./MessagesSlice";
+
+export type PollUpdateStateParams = {
+  field: string;
+  stateAccessor: string;
+  thunkToCall: () => Promise<any>;
+  attempts?: number;
+  isMany?: boolean;
+};
+
+// Used to poll for updates in users balances, needed due to fantom RPCs often taking time to return updated chain data.
+// From experiance, queries after successful transactions can take anywhere from 0-30 seconds to return updated chain data.
+export const pollUpdateState: any = createAsyncThunk(
+  "account/pollUpdateState",
+  async (
+    { field, stateAccessor, thunkToCall, attempts = 0, isMany = false }: PollUpdateStateParams,
+    { dispatch, getState },
+  ) => {
+    let state: any = getState();
+
+    const initialValue = _.get(state, stateAccessor);
+    const result: any = await thunkToCall();
+    const resultValue = _.get(result.payload, field);
+
+    // Loop is handled in the pollManyUpdateState function instead of here for querying many calls at the same time.
+    if (isMany) return initialValue !== resultValue;
+
+    if (initialValue === resultValue) {
+      if (attempts === 0) {
+        dispatch(info("Transaction successful! Please wait while we fetch your updated balances."));
+      }
+
+      if (attempts < 10) {
+        await new Promise(resolve => setTimeout(resolve, 3000));
+        dispatch(pollUpdateState({ field, stateAccessor, thunkToCall, attempts: attempts + 1 }));
+      } else {
+        dispatch(error("Oops! Couldn't update some of your balances, please try refreshing the page."));
+      }
+    }
+  },
+);
+
+type PollManyUpdateStateParams = {
+  statesToPoll: Array<PollUpdateStateParams>;
+};
+
+export const pollManyUpdateState = createAsyncThunk(
+  "account/pollUpdateManyState",
+  async ({ statesToPoll }: PollManyUpdateStateParams, { dispatch }) => {
+    let statesToCheck = statesToPoll;
+
+    for (let i = 0; i < 10; i++) {
+      const results = await Promise.all(
+        statesToCheck.map(stateCheck => dispatch(pollUpdateState({ ...stateCheck, isMany: true }))),
+      );
+
+      if (i === 0 && results.some(({ payload: success }) => !success)) {
+        dispatch(info("Transaction successful! Please wait while we fetch your updated balances."));
+      }
+
+      statesToCheck = statesToCheck.filter((_, index) => !results[index].payload);
+      if (!statesToCheck.length) break;
+
+      await new Promise(resolve => setTimeout(resolve, 3000));
+    }
+
+    if (statesToCheck.length) {
+      dispatch(error("Oops! Couldn't update some of your balances, please try refreshing the page."));
+    }
+  },
+);
+
+const initialState = {};
+
+const pollStateUpdateSlice = createSlice({
+  name: "poll",
+  initialState,
+  reducers: {
+    pollUpdateSuccess(state, action) {},
+  },
+});
+
+export default pollStateUpdateSlice.reducer;

--- a/src/views/ChooseBond/ChooseBond.tsx
+++ b/src/views/ChooseBond/ChooseBond.tsx
@@ -22,10 +22,8 @@ import { useWeb3Context } from "src/hooks/web3Context";
 import "./choosebond.scss";
 import { Skeleton } from "@material-ui/lab";
 import ClaimBonds from "./ClaimBonds";
-import isEmpty from "lodash/isEmpty";
 import { allBondsMap } from "src/helpers/AllBonds";
 import { useAppSelector } from "src/hooks";
-import { IUserBondDetails } from "src/slices/AccountSlice";
 import {
   DebtRatioGraph,
   OhmMintedGraph,
@@ -34,6 +32,7 @@ import {
 import { QueryClient, QueryClientProvider } from "react-query";
 import { useTreasuryOhm } from "../TreasuryDashboard/hooks/useTreasuryOhm";
 import styled from "styled-components";
+import _ from "lodash";
 
 function ChooseBond() {
   const { chainID } = useWeb3Context();
@@ -43,16 +42,6 @@ function ChooseBond() {
 
   const isAppLoading: boolean = useAppSelector(state => state.app.loading);
   const isAccountLoading: boolean = useAppSelector(state => state.account.loading);
-
-  const accountBonds: IUserBondDetails[] = useAppSelector(state => {
-    const withInterestDue = [];
-    for (const bond in state.account.bonds) {
-      if (state.account.bonds[bond].interestDue > 0) {
-        withInterestDue.push(state.account.bonds[bond]);
-      }
-    }
-    return withInterestDue;
-  });
 
   const marketPrice: number | undefined = useAppSelector(state => {
     return state.app.marketPrice;
@@ -75,7 +64,7 @@ function ChooseBond() {
 
   return (
     <div id="choose-bond-view">
-      {!isAccountLoading && !isEmpty(accountBonds) && <ClaimBonds activeBonds={accountBonds} />}
+      <ClaimBonds />
       <BondContainer>
         <Zoom in={true}>
           <Grid container spacing={3}>

--- a/src/views/ChooseBond/ClaimBonds.jsx
+++ b/src/views/ChooseBond/ClaimBonds.jsx
@@ -7,7 +7,9 @@ import { redeemAllBonds, redeemBond } from "src/slices/BondSlice";
 import { calculateUserBondDetails } from "src/slices/AccountSlice";
 import CardHeader from "../../components/CardHeader/CardHeader";
 import { useWeb3Context } from "src/hooks/web3Context";
+import { useAppSelector } from "src/hooks";
 import useBonds from "src/hooks/Bonds";
+import { IUserBondDetails } from "src/slices/AccountSlice";
 import {
   Button,
   Box,
@@ -24,7 +26,7 @@ import useMediaQuery from "@material-ui/core/useMediaQuery";
 import "./choosebond.scss";
 import { useSelector, useDispatch } from "react-redux";
 
-function ClaimBonds({ activeBonds }) {
+function ClaimBonds() {
   const dispatch = useDispatch();
   const { provider, address, chainID } = useWeb3Context();
   const { bonds } = useBonds(chainID);
@@ -35,6 +37,16 @@ function ClaimBonds({ activeBonds }) {
   const pendingTransactions = useSelector(state => {
     return state.pendingTransactions;
   });
+
+  const activeBonds: IUserBondDetails[] = useAppSelector(state => {
+    const withInterestDue = [];
+    for (const bond in state.account.bonds) {
+      if (state.account.bonds[bond].interestDue > 0) {
+        withInterestDue.push(state.account.bonds[bond]);
+      }
+    }
+    return withInterestDue;
+  }, _.isEqual);
 
   const pendingClaim = () => {
     if (
@@ -52,14 +64,15 @@ function ClaimBonds({ activeBonds }) {
   const onRedeemAll = async ({ autostake }) => {
     console.log("redeeming all bonds");
 
-    await dispatch(redeemAllBonds({ address, bonds, networkID: chainID, provider, autostake }));
+    const bondsToRedeem = bonds.filter(bond => activeBonds.some(activeBond => activeBond.bond === bond.name));
+    await dispatch(redeemAllBonds({ address, bonds: bondsToRedeem, networkID: chainID, provider, autostake }));
 
     console.log("redeem all complete");
   };
 
   useEffect(() => {
-    let bondCount = Object.keys(activeBonds).length;
-    setNumberOfBonds(bondCount);
+    let bondCount = Object.keys(activeBonds || {}).length;
+    if (bondCount !== numberOfBonds) setNumberOfBonds(bondCount);
   }, [activeBonds]);
 
   return (

--- a/src/views/Stake/Stake.tsx
+++ b/src/views/Stake/Stake.tsx
@@ -122,6 +122,7 @@ function Stake() {
     }
 
     await dispatch(changeStake({ address, action, value: quantity.toString(), provider, networkID: chainID }));
+    setQuantity(0);
   };
 
   const hasAllowance = useCallback(


### PR DESCRIPTION
## Changes
- Create a new slice which polls for an update of state via another async thunk
- Create a new slice which polls for many updates of states via several different async thunks
- Call either of these two after transactions which are expected to update user values as opposed to calling once and hoping it updates.
- The above thunks attempt 10 calls over 30 seconds (3 second intervals). If no update occurs after this - it gives up and alerts the user to refresh.
- The user is alerted that we are attempting to update the users balances IF the first call doesn't update the balance.
- This has been applied for: 
  - Approve Stake/Unstake/Bond
  - Claim/Claim and stake single bond
  - Claim/Claim and stake all bonds
  - Stake EXOD
  - Unstake EXOD

**Example:** (Ignore the initial balance refresh, it had been a while since i refreshed my site and it's not dependant on that value)
![refresh-balances](https://user-images.githubusercontent.com/86249394/145675778-4c74403a-97f2-4cb8-b8c3-0a4b1e29665b.gif)

