### PR TITLE
[EXOD-000] Fix tooltip dates and show total for some charts

### DIFF
--- a/src/components/Chart/CustomTooltip.jsx
+++ b/src/components/Chart/CustomTooltip.jsx
@@ -1,9 +1,12 @@
-import { Paper, Box, Typography } from "@material-ui/core";
+import { Paper, Box, Typography, useTheme } from "@material-ui/core";
 import { bulletpoints } from "src/views/TreasuryDashboard/treasuryData";
+import _ from "lodash";
 import "./customtooltip.scss";
 
 const renderDate = (index, payload, item) => {
-  return index === payload.length - 1 && item.payload.timestamp ? (
+  const filteredPayloads = _.uniqBy(payload, "name");
+
+  return index === filteredPayloads.length - 1 && item.payload.timestamp ? (
     <div className="tooltip-date">
       {new Date(item.payload.timestamp * 1000).toLocaleString("default", { month: "long" }).charAt(0).toUpperCase()}
       {new Date(item.payload.timestamp * 1000).toLocaleString("default", { month: "long" }).slice(1)}
@@ -36,7 +39,10 @@ const renderTooltipItems = (
   isPie = false,
   colors,
   dataKey,
+  showTotal,
 ) => {
+  const theme = useTheme();
+
   return isStaked ? (
     <Box>
       <Box className="item" display="flex" justifyContent="space-between">
@@ -110,10 +116,28 @@ const renderTooltipItems = (
               </Box>
               {renderItem(isDilution ? itemType[itemIndex] : itemType, item.value)}
             </Box>
-            <Box>{renderDate(itemIndex, payload, item)}</Box>
+            <Box>{!showTotal && renderDate(itemIndex, payload, item)}</Box>
           </Box>
         );
       })}
+      {showTotal && <br />}
+      {showTotal && (
+        <Box key={payload.length}>
+          <Box className="item" display="flex">
+            <Box display="flex" justifyContent="space-between">
+              <Typography variant="body2" className="field-name">
+                <span className="tooltip-bulletpoint" style={{ backgroundColor: theme.palette.text.secondary }}></span>
+                Total
+              </Typography>
+            </Box>
+            {renderItem(
+              itemType,
+              payload.reduce((total, item) => total + item.value, 0),
+            )}
+          </Box>
+          <Box>{renderDate(payload.length - 1, payload, payload[0])}</Box>
+        </Box>
+      )}
     </>
   );
 };
@@ -130,6 +154,7 @@ function CustomTooltip({
   isDilution,
   isPie,
   colors,
+  showTotal = false,
 }) {
   if (active && payload && payload.length) {
     return (
@@ -145,6 +170,7 @@ function CustomTooltip({
           isPie,
           colors,
           dataKey,
+          showTotal,
         )}
       </Paper>
     );

--- a/src/components/Chart/ExodiaChart.jsx
+++ b/src/components/Chart/ExodiaChart.jsx
@@ -193,6 +193,7 @@ export const ExodiaStackedLineChart = withChartCard(
     expandedGraphStrokeColor,
     strokeWidth = 1.6,
     glowDeviation = "6",
+    showTotal,
   }) => {
     const theme = useTheme();
     // Remove 0's
@@ -236,6 +237,7 @@ export const ExodiaStackedLineChart = withChartCard(
                 itemType={itemType}
                 colors={colors}
                 dataKey={dataKey}
+                showTotal={showTotal}
               />
             }
           />
@@ -268,6 +270,7 @@ export const ExodiaMultiLineChart = withChartCard(
     strokeWidth = 1.6,
     dataAxis = [],
     isDilution = false,
+    showTotal,
   }) => {
     const theme = useTheme();
     // Remove 0's
@@ -330,6 +333,7 @@ export const ExodiaMultiLineChart = withChartCard(
                 colors={colors}
                 dataKey={dataKey}
                 isDilution={isDilution}
+                showTotal={showTotal}
               />
             }
           />

--- a/src/themes/dark.js
+++ b/src/themes/dark.js
@@ -126,6 +126,9 @@ export const dark = responsiveFontSizes(
               color: darkTheme.color,
               backdropFilter: "blur(15px)",
             },
+            "&.tooltip-container": {
+              backgroundColor: `${darkTheme.paperBg}DD`,
+            },
           },
         },
         MuiTooltip: {

--- a/src/views/TreasuryDashboard/components/Graph/Graph.js
+++ b/src/views/TreasuryDashboard/components/Graph/Graph.js
@@ -72,8 +72,6 @@ export const MarketValueGraph = ({ isDashboard = false }) => {
       };
     });
 
-  console.log(stats);
-
   const value =
     ethData && stats && stats[0].treasuryDaiMarketValue + stats[0].treasuryWETHMarketValue + stats[0].sOHMBalanceUSD;
   const lastValue =
@@ -101,6 +99,7 @@ export const MarketValueGraph = ({ isDashboard = false }) => {
       infoTooltipMessage={tooltipInfoMessages.mvt}
       expandedGraphStrokeColor={theme.palette.graphStrokeColor}
       isDashboard={isDashboard}
+      showTotal
     />
   );
 };
@@ -393,6 +392,7 @@ export const DebtRatioGraph = () => {
       infoTooltipMessage={tooltipInfoMessages.debtratio}
       expandedGraphStrokeColor={theme.palette.graphStrokeColor}
       isDebt={true}
+      showTotal
     />
   );
 };


### PR DESCRIPTION
- Tooltip dates weren't showing for some charts which had fancy underglow
- Added a `showTotal` prop to the chart tooltips for the tooltip to render a total of the values for that date.
![Screenshot from 2021-12-28 00-02-12](https://user-images.githubusercontent.com/86249394/147491026-9b26356d-a634-4881-bcd9-680eeea86f97.png)

