### PR TITLE
Update Treasury Analytics

### DIFF
--- a/src/themes/dark.js
+++ b/src/themes/dark.js
@@ -36,7 +36,7 @@ export const darkTheme = {
   containedSecondaryButtonHoverBG: "rgba(255, 255, 255, 0.15)",
   graphStrokeColor: "rgba(255, 255, 255, .1)",
   sidebarBackground: `linear-gradient(0deg, rgba(31,31,31,1) 0%, rgba(0,0,0,0) 50%, rgba(0,0,0,0) 100%), url(${navBg})`,
-  chartColors: ["#46ab15", "#ebc342", "#db3737", "#598fb5", "#775bb5", "#888888"],
+  chartColors: ["#46ab15", "#ebc342", "#db3737", "#598fb5", "#775bb5", "#42bd8c", "#888888"],
   trendUp: "#43e055",
   trendDown: "#ed3939",
   mainBackground:

--- a/src/views/ChooseBond/ChooseBond.tsx
+++ b/src/views/ChooseBond/ChooseBond.tsx
@@ -50,7 +50,7 @@ function ChooseBond() {
 
   return (
     <div id="choose-bond-view">
-      <Paper className="ohm-card" style={{ padding: 0, border: "none" }}>
+      <Paper className="ohm-card" style={{ padding: 0, marginBottom: "1rem", border: "none" }}>
         <MigrationBanner />
       </Paper>
       <ClaimBonds />

--- a/src/views/TreasuryDashboard/components/Graph/Graph.js
+++ b/src/views/TreasuryDashboard/components/Graph/Graph.js
@@ -83,6 +83,7 @@ export const MarketValueGraph = ({ isDashboard = false }) => {
         "treasuryMaiBalance",
         "treasuryWETHMarketValue",
         "treasuryGOhmMarketValue",
+        "treasuryfBeetsValue",
       ]}
       colors={theme.palette.chartColors}
       dataFormat="$"
@@ -404,31 +405,41 @@ export const DebtRatioGraph = () => {
     data &&
     data.map(entry => ({
       timestamp: entry.timestamp,
-      daiDebtRatio: entry.dai_debt_ratio / 1e10,
-      ethDebtRatio: entry.eth_debt_ratio / 1e10,
-      ohmDaiDebtRatio: entry.ohmdai_debt_ratio / 1e19,
-      monolithDebtRatio: entry.monolith_debt_ratio / 1e10,
-      gOhmDebtRatio: entry.gOhm_debt_ratio / 1e10,
+      daiDebtRatio: entry.dai_debt_ratio / 1e8,
+      ethDebtRatio: entry.eth_debt_ratio / 1e8,
+      ohmDaiDebtRatio: entry.ohmdai_debt_ratio / 1e17,
+      monolithDebtRatio: Math.max(entry.monolith_debt_ratio / 1e8 || 0, entry.monolithV2_debt_ratio / 1e8 || 0),
+      gOhmDebtRatio: entry.gOhm_debt_ratio / 1e8,
+      fBeetsDebtRatio: entry.fBeets_debt_ratio / 1e8,
     }));
 
   return (
     <ExodiaMultiLineChart
       deviation="2"
       data={debtRatios}
-      dataKey={["daiDebtRatio", "ethDebtRatio", "ohmDaiDebtRatio", "monolithDebtRatio", "gOhmDebtRatio"]}
+      dataKey={[
+        "daiDebtRatio",
+        "ethDebtRatio",
+        "ohmDaiDebtRatio",
+        "monolithDebtRatio",
+        "gOhmDebtRatio",
+        "fBeetsDebtRatio",
+      ]}
       colors={[
         theme.palette.chartColors[1],
         theme.palette.chartColors[3],
-        theme.palette.chartColors[5],
+        theme.palette.chartColors[6],
         theme.palette.chartColors[0],
         theme.palette.chartColors[4],
+        theme.palette.chartColors[5],
       ]}
       stroke={[
         theme.palette.chartColors[1],
         theme.palette.chartColors[3],
-        theme.palette.chartColors[5],
+        theme.palette.chartColors[6],
         theme.palette.chartColors[0],
         theme.palette.chartColors[4],
+        theme.palette.chartColors[5],
       ]}
       headerText="Debt Ratios"
       headerSubText={`Total ${
@@ -613,12 +624,14 @@ export const TreasuryBreakdownPie = () => {
   const maiValue = data && data[0].treasuryMaiBalance;
   const ftmValue = data && data[0].treasuryWETHMarketValue;
   const gOhmValue = data && data[0].treasuryGOhmMarketValue;
+  const fBeetsValue = data && data[0].treasuryfBeetsValue;
 
   const exodValuePrevious = data && data[1].treasuryMonolithExodValue + data[1].treasuryMonolithWsExodValue;
   const daiValuePrevious = data && data[1].treasuryDaiMarketValue;
   const maiValuePrevious = data && data[1].treasuryMaiBalance;
   const ftmValuePrevious = data && data[1].treasuryWETHMarketValue;
   const gOhmValuePrevious = data && data[1].treasuryGOhmMarketValue;
+  const fBeetsValuePrevious = data && data[1].treasuryfBeetsValue;
 
   const totalValue = data && data[0].treasuryMarketValue;
   const lastValue = data && data[1].treasuryMarketValue;
@@ -631,6 +644,7 @@ export const TreasuryBreakdownPie = () => {
     { value: Number(trim((maiValue / totalValue) * 100, 2)), name: "MAI" },
     { value: Number(trim((ftmValue / totalValue) * 100, 2)), name: "wFTM" },
     { value: Number(trim((gOhmValue / totalValue) * 100, 2)), name: "gOHM" },
+    { value: Number(trim((fBeetsValue / totalValue) * 100, 2)), name: "fBEETS" },
   ];
 
   return (
@@ -680,8 +694,15 @@ export const TreasuryBreakdownPie = () => {
       </Grid>
       <Grid xs={isVerySmallScreen ? 12 : 7} sm={7} md={7} lg={7} style={{ height: "50%" }}>
         <TreasuryTable
-          currentData={[exodValue, daiValue, maiValue, ftmValue, gOhmValue]}
-          previousData={[exodValuePrevious, daiValuePrevious, maiValuePrevious, ftmValuePrevious, gOhmValuePrevious]}
+          currentData={[exodValue, daiValue, maiValue, ftmValue, gOhmValue, fBeetsValue]}
+          previousData={[
+            exodValuePrevious,
+            daiValuePrevious,
+            maiValuePrevious,
+            ftmValuePrevious,
+            gOhmValuePrevious,
+            fBeetsValuePrevious,
+          ]}
           itemNames={tooltipItems.coin}
           colors={theme.palette.chartColors}
           totalValue={totalValue}
@@ -805,8 +826,8 @@ const TableGrid = styled.div`
   padding-left: 12px;
   grid-row-gap: 12px;
 
-  ${({ header }) => header && "padding-bottom: 12px;  margin-top: 42px;"}
-  ${({ header, isSmallScreen }) => header && isSmallScreen && "margin-top: 42px;"}
+  ${({ header }) => header && "padding-bottom: 12px;  margin-top: 32px;"}
+  ${({ header, isSmallScreen }) => header && isSmallScreen && "margin-top: 32px;"}
 `;
 
 const ColorMark = styled.div`

--- a/src/views/TreasuryDashboard/components/Metric/Metric.js
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.js
@@ -100,7 +100,12 @@ export const CircSupply = ({ isDashboard = false }) => {
 };
 
 export const BackingPerOHM = ({ isDashboard = false }) => {
-  const backingPerOhm = useSelector(state => state.app.treasuryMarketValue / state.app.circSupply);
+  const { data } = useTreasuryMetrics({ refetchOnMount: false });
+  const circSupply = useSelector(state => state.app.circSupply);
+
+  const backing =
+    data && data[0].treasuryMarketValue - data[0].treasuryMonolithExodValue - data[0].treasuryMonolithWsExodValue;
+  const backingPerOhm = backing && circSupply && backing / circSupply;
   const Title = isDashboard ? Metric.SmallTitle : Metric.Title;
   const Value = isDashboard ? Metric.SmallValue : Metric.Value;
 

--- a/src/views/TreasuryDashboard/treasuryData.ts
+++ b/src/views/TreasuryDashboard/treasuryData.ts
@@ -35,6 +35,8 @@ query {
     treasuryMonolithWFtmBalance
     treasuryMonolithGOhmValue
     treasuryMonolithGOhmBalance
+    treasuryfBeetsBalance
+    treasuryfBeetsValue
     currentAPY
     runway10k
     runway20k
@@ -79,6 +81,8 @@ query {
     ohmdai_debt_ratio
     monolith_debt_ratio
     gOhm_debt_ratio
+    monolithV2_debt_ratio
+    fBeets_debt_ratio
     timestamp
   }
 }
@@ -214,7 +218,7 @@ export const bulletpoints = {
 
 export const tooltipItems = {
   tvl: [t`Total Value Deposited`],
-  coin: [t`EXOD`, t`DAI`, t`MAI`, t`wFTM`, t`gOHM`],
+  coin: [t`EXOD`, t`DAI`, t`MAI`, t`wFTM`, t`gOHM`, t`fBEETS`],
   rfv: [t`DAI`, t`MAI`],
   holder: [t`Exodians`],
   apy: [t`APY`],
@@ -230,6 +234,7 @@ export const tooltipItems = {
     t`EXOD-DAI spLP Debt Ratio`,
     t`The Monolith LP Debt Ratio`,
     t`gOHM Debt Ratio`,
+    t`fBEETS Debt Ratio`,
   ],
   indexAdjustedPrice: [t`Market Price`, t`Index Adjusted Price`],
   growthOfSupply: [t`Index Adjusted Supply`, t`Circulating Supply`],
@@ -243,7 +248,7 @@ export const tooltipInfoMessages = {
   pol: t`Protocol Owned Liquidity, is the amount of LP the treasury owns and controls. The more POL the better for the protocol and its users.`,
   holder: t`Holders, represents the total number of Exodians (sEXOD holders)`,
   staked: t`Staked supply is the percentage of circulating EXOD tokens which are currently staked.`,
-  backing: t`Backing is the dollar value of assets from the treasury backing a single EXOD.`,
+  backing: t`Backing is the dollar value of non EXOD assets from the treasury backing a single EXOD.`,
   supply: t`Supply (Circulating/Total) represents the circulating and total amount of EXOD in existence. The circulating supply includes all staked EXOD, wsEXOD and EXOD in liquidity pools while the total also includes EXOD in the DAO treasury.`,
   apy: t`Annual Percentage Yield, is the normalized representation of an interest rate, based on a compounding period over one year. Note that APYs provided are rather ballpark level indicators and not so much precise future results.`,
   runway: t`Runway, is the number of days sEXOD emissions can be sustained at a given rate. Lower APY = longer runway`,


### PR DESCRIPTION
- Add fBEETS to treasury charts and debt ratio charts
- Update backing to exclude EXOD
- Change the division used in the debt ratio charts (its the same number as the bond card but we divide by `1e10` when it should have been `1e8`