### PR TITLE
RPC error improvements / Small screen fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,7 +144,7 @@ function App() {
   // ... if we don't wait we'll ALWAYS fire API calls via JsonRpc because provider has not
   // ... been reloaded within App.
   useEffect(() => {
-    dispatch(loadGraphData());
+    dispatch(loadGraphData({}));
     if (hasCachedProvider()) {
       // then user DOES have a wallet
       connect().then(() => {

--- a/src/components/Chart/ExodiaChart.jsx
+++ b/src/components/Chart/ExodiaChart.jsx
@@ -485,7 +485,7 @@ export const ExodiaPieChart = withChartCard(
     strokeWidth = 1.6,
   }) => {
     const isSmallScreen = useMediaQuery("(max-width: 550px)");
-    const isVerySmallScreen = useMediaQuery("(max-width: 400px)");
+    const isVerySmallScreen = useMediaQuery("(max-width: 450px)");
 
     return (
       <ResponsiveContainer minHeight={260} width="100%">
@@ -525,7 +525,7 @@ export const ExodiaPieChart = withChartCard(
 export const trimNumber = number => {
   if (Number(number) > 1000000) return `${(parseFloat(number) / 1000000).toFixed(1)}M`;
   else if (Number(number) > 1000) return `${(parseFloat(number) / 1000).toFixed(0)}k`;
-  return number;
+  return number ? number.toFixed(1) : "-";
 };
 
 const tickFormatter = (number, dataFormat) => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ export const THE_GRAPH_URL_ETH = "https://api.thegraph.com/subgraphs/name/exodia
 export const BEETS_LINK = "https://beets.fi/#/trade/fantom/0x3b57f3feaaf1e8254ec680275ee6e7727c7413c7";
 export const EPOCH_INTERVAL = 28800;
 
+export const MAX_RETRY_ATTEMPTS = 10;
 // NOT USED ANY MORE: Fetched from the blockchain `useAppSelector(state => state.app.blockRateSeconds)`
 export const BLOCK_RATE_SECONDS = 0.9;
 

--- a/src/slices/AccountSlice.ts
+++ b/src/slices/AccountSlice.ts
@@ -1,5 +1,5 @@
 import { BigNumber, BigNumberish, ethers } from "ethers";
-import { addresses } from "../constants";
+import { addresses, MAX_RETRY_ATTEMPTS } from "../constants";
 import { abi as ierc20Abi } from "../abi/IERC20.json";
 import { abi as sOHMv2 } from "../abi/sOhmv2.json";
 import { abi as wsOHM } from "../abi/wsOHM.json";
@@ -63,7 +63,7 @@ export const getBalances = createAsyncThunk(
         },
       };
     } catch (e) {
-      if (attempts < 5) {
+      if (attempts < MAX_RETRY_ATTEMPTS) {
         const newAttempts = attempts + 1;
         dispatch(loadAccountDetails({ networkID, provider, address, attempts: newAttempts }));
       } else {
@@ -124,7 +124,7 @@ export const loadAccountDetails = createAsyncThunk(
         },
       };
     } catch (e) {
-      if (attempts < 5) {
+      if (attempts < MAX_RETRY_ATTEMPTS) {
         const newAttempts = attempts + 1;
         dispatch(loadAccountDetails({ networkID, provider, address, attempts: newAttempts }));
       } else {
@@ -196,7 +196,7 @@ export const calculateUserBondDetails = createAsyncThunk(
         pendingPayout: ethers.utils.formatUnits(pendingPayout, "gwei"),
       };
     } catch (e) {
-      if (attempts < 5) {
+      if (attempts < MAX_RETRY_ATTEMPTS) {
         const newAttempts = attempts + 1;
         dispatch(calculateUserBondDetails({ address, bond, networkID, provider, attempts: newAttempts }));
       } else {

--- a/src/slices/AppSlice.ts
+++ b/src/slices/AppSlice.ts
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import { addresses, EPOCH_INTERVAL } from "../constants";
+import { addresses, EPOCH_INTERVAL, MAX_RETRY_ATTEMPTS } from "../constants";
 import { abi as OlympusStakingv2ABI } from "../abi/OlympusStakingv2.json";
 import { abi as sOHMv2 } from "../abi/sOhmv2.json";
 import { setAll, getTokenPrice, getMarketPrice, secondsUntilBlock, prettifySeconds } from "../helpers";
@@ -75,7 +75,7 @@ export const loadAppDetails = createAsyncThunk(
         blockRateSeconds,
       } as IAppData;
     } catch (e) {
-      if (attempts < 5) {
+      if (attempts < MAX_RETRY_ATTEMPTS) {
         const newAttempts = attempts + 1;
         dispatch(loadAppDetails({ networkID, provider, attempts: newAttempts }));
       } else {
@@ -138,7 +138,7 @@ export const loadGraphData = createAsyncThunk(
         marketPrice,
       } as IAppData;
     } catch (e) {
-      if (attempts < 5) {
+      if (attempts < MAX_RETRY_ATTEMPTS) {
         const newAttempts = attempts + 1;
         dispatch(loadGraphData({ attempts: newAttempts }));
       } else {
@@ -213,7 +213,7 @@ export const refreshRebaseTimer = createAsyncThunk(
 
       return { secondsUntilRebase: seconds };
     } catch (e) {
-      if (attempts < 5) {
+      if (attempts < MAX_RETRY_ATTEMPTS) {
         const newAttempts = attempts + 1;
         dispatch(loadGraphData({ attempts: newAttempts }));
       } else {

--- a/src/slices/BondSlice.ts
+++ b/src/slices/BondSlice.ts
@@ -1,5 +1,6 @@
 import { ethers, BigNumber, BigNumberish } from "ethers";
 import { contractForRedeemHelper } from "../helpers";
+import { MAX_RETRY_ATTEMPTS } from "../constants";
 import { getBalances, calculateUserBondDetails } from "./AccountSlice";
 import { pollUpdateState, pollManyUpdateState, PollUpdateStateParams } from "./PollStateUpdateSlice";
 import { findOrLoadMarketPrice } from "./AppSlice";
@@ -185,7 +186,7 @@ export const calcBondDetails = createAsyncThunk(
         purchaseDisabled,
       };
     } catch (e) {
-      if (attempts < 5) {
+      if (attempts < MAX_RETRY_ATTEMPTS) {
         const newAttempts = attempts + 1;
         dispatch(calcBondDetails({ bond, value, provider, networkID, attempts: newAttempts }));
       } else {

--- a/src/slices/PollStateUpdateSlice.ts
+++ b/src/slices/PollStateUpdateSlice.ts
@@ -33,7 +33,7 @@ export const pollUpdateState: any = createAsyncThunk(
         dispatch(info("Transaction successful! Please wait while we fetch your updated balances."));
       }
 
-      if (attempts < 10) {
+      if (attempts < MAX_RETRY_ATTEMPTS) {
         await new Promise(resolve => setTimeout(resolve, 3000));
         dispatch(pollUpdateState({ field, stateAccessor, thunkToCall, attempts: attempts + 1 }));
       } else {

--- a/src/slices/interfaces.ts
+++ b/src/slices/interfaces.ts
@@ -9,6 +9,7 @@ export interface IJsonRPCError {
 export interface IBaseAsyncThunk {
   readonly networkID: NetworkID;
   readonly provider: StaticJsonRpcProvider | JsonRpcProvider;
+  readonly attempts?: number;
 }
 
 export interface IChangeApprovalAsyncThunk extends IBaseAsyncThunk {

--- a/src/views/Dashboard/Dashboard.jsx
+++ b/src/views/Dashboard/Dashboard.jsx
@@ -35,7 +35,7 @@ import MigrationMessage from "src/components/MigrationMessage";
 const Dashboard = memo(() => {
   const theme = useTheme();
   const isSmallScreen = useMediaQuery("(max-width: 650px)");
-  const isVerySmallScreen = useMediaQuery("(max-width: 400px)");
+  const isVerySmallScreen = useMediaQuery("(max-width: 450px)");
   // Use marketPrice as indicator of loading.
   const isAppLoading = useSelector(state => !state.app?.marketPrice ?? true);
   const marketPrice = useSelector(state => {
@@ -125,7 +125,7 @@ const Dashboard = memo(() => {
             <Grid item lg={6} md={12} sm={12} xs={12}>
               <Paper
                 className="ohm-card"
-                style={{ paddingBottom: "5px", maxHeight: "440px", height: isVerySmallScreen ? "440px" : "auto" }}
+                style={{ paddingBottom: "5px", maxHeight: "450px", height: isVerySmallScreen ? "450px" : "auto" }}
               >
                 <TreasuryBreakdownPie />
               </Paper>

--- a/src/views/Dashboard/QuickRedeem.jsx
+++ b/src/views/Dashboard/QuickRedeem.jsx
@@ -148,7 +148,7 @@ const Container = styled.div`
 `;
 
 const InputContainer = styled(Container)`
-  @media (max-width: 450px) {
+  @media (max-width: 500px) {
     flex-direction: column;
 
     button {

--- a/src/views/Dashboard/QuickStaking.jsx
+++ b/src/views/Dashboard/QuickStaking.jsx
@@ -279,7 +279,7 @@ const InputContainer = styled(Container)`
   .help-text {
     margin-right: 12px;
   }
-  @media (max-width: 450px) {
+  @media (max-width: 500px) {
     flex-direction: column;
 
     button {

--- a/src/views/TreasuryDashboard/components/Graph/Graph.js
+++ b/src/views/TreasuryDashboard/components/Graph/Graph.js
@@ -617,7 +617,7 @@ export const DashboardPriceGraph = ({ isDashboard = false }) => {
 export const TreasuryBreakdownPie = () => {
   const theme = useTheme();
   const { data } = useTreasuryMetrics({ refetchOnMount: false });
-  const isVerySmallScreen = useMediaQuery("(max-width: 400px)");
+  const isVerySmallScreen = useMediaQuery("(max-width: 450px)");
 
   const exodValue = data && data[0].treasuryMonolithExodValue + data[0].treasuryMonolithWsExodValue;
   const daiValue = data && data[0].treasuryDaiMarketValue;
@@ -724,17 +724,17 @@ const TreasuryTable = ({ currentData, previousData, totalValue, lastValue, itemN
             <Trans>Asset</Trans>
           </Typography>
         </Cell>
-        <Cell>
+        <Cell center>
           <Typography variant="body1" color="textSecondary">
             <Trans>Value</Trans>
           </Typography>
         </Cell>
-        <Cell>
+        <Cell center>
           <Typography variant="body1" color="textSecondary">
             <Trans>%</Trans>
           </Typography>
         </Cell>
-        <Cell>
+        <Cell center>
           <Typography variant="body1" color="textSecondary">
             <Trans>Change</Trans>
           </Typography>
@@ -748,17 +748,17 @@ const TreasuryTable = ({ currentData, previousData, totalValue, lastValue, itemN
                 <ColorMark color={colors[index]} />
                 <Typography variant="body1">{name}</Typography>
               </Cell>
-              <Cell>
+              <Cell center>
                 <Typography variant="body1">
                   {isSmallScreen ? `$${trimNumber(currentData[index])}` : formatCurrency(currentData[index])}
                 </Typography>
               </Cell>
-              <Cell>
+              <Cell center>
                 <Typography variant="body1">
                   {trim((currentData[index] / totalValue) * 100, isSmallScreen ? 0 : 1)}%
                 </Typography>
               </Cell>
-              <Cell>
+              <Cell center>
                 <Typography variant="body1">
                   <Trend
                     value={currentData[index]}
@@ -827,7 +827,7 @@ const TableGrid = styled.div`
   grid-row-gap: 12px;
 
   ${({ header }) => header && "padding-bottom: 12px;  margin-top: 32px;"}
-  ${({ header, isSmallScreen }) => header && isSmallScreen && "margin-top: 32px;"}
+  ${({ header, isSmallScreen }) => header && isSmallScreen && "margin-top: 42px;"}
 `;
 
 const ColorMark = styled.div`
@@ -841,4 +841,5 @@ const ColorMark = styled.div`
 const Cell = styled.div`
   display: flex;
   align-items: center;
+  ${({ center }) => center && "justify-self: center;"}
 `;


### PR DESCRIPTION
- Fixes small screen issues
- Improve `Internal JSON-RPC error` handling
  - Wrap all data load slices in a `try/catch` block.
  - Retry slice if it failed
  - Retry to a maximum of 10 times 
  - If an error continues to occur then we show an error toast to the user letting them know what failed to load and asking them to refresh.

Ideally I'd like to catch the specific error, but this is JavaScript and AFAIK the only way to do so would be `error.message === "Internal JSON-RPC error."`  but this is prone to breaking if the error message changes or is different. Happy to do it if you think it's better though.

On testing I an error or two every 10 refreshers and most only took 1 or 2 retries to be successful so 10 seems like a good limit just to be on the safe side in times of congestion.